### PR TITLE
Improve Vempain admin calling

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ junitVersion=5.13.3
 # https://github.com/Vempain/vempain-auth/packages/2614500
 vempainAuthVersion=0.9.2
 # https://github.com/Vempain/vempain-admin-backend/packages/2624185
-vempainAdminVersion=0.9.21
+vempainAdminVersion=0.9.22


### PR DESCRIPTION
This pull request updates the file publishing workflow to improve metadata handling and maintain compatibility with the latest `vempain-admin-backend` version. The main changes center around how file metadata and mimetype are extracted and used when publishing files.

**Dependency update:**

* Updated `vempainAdminVersion` in `gradle.properties` from `0.9.21` to `0.9.22` to use the latest backend features and fixes.

**File publishing workflow improvements:**

* Added a new import for `MetadataTool` in `PublishService.java` to enable advanced metadata extraction.
* Refactored the file publishing logic in `publishFileGroup` to use `MetadataTool` for extracting metadata and mimetype from the exported file, replacing the previous manual assignment and property extraction. The ingest request is now built using the builder pattern for clarity and maintainability.