### PR TITLE
Pass the ingest DTO as string in multipart call to Vempain admin

### DIFF
--- a/api/src/main/java/fi/poltsi/vempain/file/VempainServiceApiDefinition.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/VempainServiceApiDefinition.java
@@ -5,8 +5,8 @@ import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.servers.Server;
 import lombok.experimental.UtilityClass;
 
-@OpenAPIDefinition(info = @Info(version = "${info.build.version}", title = "Vempain Service REST endpoints"),
-				   servers = @Server(url = "http://localhost:8080/api", description = "current server"))
+@OpenAPIDefinition(info = @Info(version = "${info.build.version}", title = "Vempain File Service REST endpoints"),
+				   servers = @Server(url = "http://localhost:${server.port}/api", description = "current server"))
 @UtilityClass
 public class VempainServiceApiDefinition {
 }

--- a/api/src/main/java/fi/poltsi/vempain/file/api/response/FileGroupResponse.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/api/response/FileGroupResponse.java
@@ -1,5 +1,7 @@
 package fi.poltsi.vempain.file.api.response;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
@@ -13,6 +15,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Schema(name = "FileGroupResponse", description = "Represents a file group and its files")
 @Tag(name = "FileGroups", description = "Schema for FileGroupResponse")
 public class FileGroupResponse {

--- a/api/src/main/java/fi/poltsi/vempain/file/rest/FileGroupAPI.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/rest/FileGroupAPI.java
@@ -1,4 +1,4 @@
-package fi.poltsi.vempain.file.api;
+package fi.poltsi.vempain.file.rest;
 
 import fi.poltsi.vempain.file.api.response.FileGroupResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Positive;
 import org.springframework.http.MediaType;
@@ -32,6 +33,7 @@ public interface FileGroupAPI {
 			@ApiResponse(responseCode = "404", description = "No file group found", content = @Content),
 			@ApiResponse(responseCode = "500", description = "Internal server error", content = @Content)
 	})
+	@SecurityRequirement(name = "Bearer Authentication")
 	@GetMapping(path = BASE_PATH, produces = "application/json")
 	ResponseEntity<List<FileGroupResponse>> getFileGroups();
 
@@ -45,6 +47,7 @@ public interface FileGroupAPI {
 			@ApiResponse(responseCode = "404", description = "No file group found", content = @Content),
 			@ApiResponse(responseCode = "500", description = "Internal server error", content = @Content)
 	})
+	@SecurityRequirement(name = "Bearer Authentication")
 	@GetMapping(path = BASE_PATH + "/{id}", produces = "application/json")
 	ResponseEntity<FileGroupResponse> getFileGroupById(@PathVariable("id") @Positive Long id);
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ junitVersion=5.13.4
 # https://github.com/Vempain/vempain-auth/packages/2614500
 vempainAuthVersion=0.9.8
 # https://github.com/Vempain/vempain-admin-backend/packages/2624185
-vempainAdminVersion=0.9.24
+vempainAdminVersion=0.9.25

--- a/service/src/main/java/fi/poltsi/vempain/file/controller/FileGroupController.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/controller/FileGroupController.java
@@ -1,7 +1,7 @@
 package fi.poltsi.vempain.file.controller;
 
-import fi.poltsi.vempain.file.api.FileGroupAPI;
 import fi.poltsi.vempain.file.api.response.FileGroupResponse;
+import fi.poltsi.vempain.file.rest.FileGroupAPI;
 import fi.poltsi.vempain.file.service.FileGroupService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/service/src/main/java/fi/poltsi/vempain/file/feign/VempainAdminFileIngestClient.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/feign/VempainAdminFileIngestClient.java
@@ -3,7 +3,7 @@ package fi.poltsi.vempain.file.feign;
 import fi.poltsi.vempain.admin.rest.file.FileIngestAPI;
 import org.springframework.cloud.openfeign.FeignClient;
 
-@FeignClient(name = "vempain-admin-file-ingest", url = "${vempain.service.admin-backend-url}", configuration = VempainAdminFeignConfig.class)
+@FeignClient(name = "vempain-admin-file-ingest", url = "${vempain.service.admin-backend-url}")
 public interface VempainAdminFileIngestClient extends FileIngestAPI {
 
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/service/VempainAdminService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/VempainAdminService.java
@@ -1,5 +1,7 @@
 package fi.poltsi.vempain.file.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import fi.poltsi.vempain.admin.api.request.file.FileIngestRequest;
 import fi.poltsi.vempain.auth.exception.VempainAuthenticationException;
 import fi.poltsi.vempain.file.feign.VempainAdminFileIngestClient;
@@ -20,10 +22,19 @@ public class VempainAdminService {
 												.path(exportedFile.toPath())
 												.contentType(fileIngestRequest.getMimeType())
 												.build();
+		// Convert request to JSON string
+		var    mapper = new ObjectMapper();
+		String fileIngestRequestString;
 
+		try {
+			fileIngestRequestString = mapper.writeValueAsString(fileIngestRequest);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
 
 		log.info("Uploading file {} to Vempain Admin service", exportedFile.getAbsolutePath());
-		var responseEntity = vempainAdminFileIngestClient.ingest(fileIngestRequest, multiPartFile);
+		// Pass JSON string instead of object
+		var responseEntity = vempainAdminFileIngestClient.ingest(fileIngestRequestString, multiPartFile);
 
 		if (responseEntity == null || !responseEntity.getStatusCode()
 													 .is2xxSuccessful()) {

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -48,7 +48,8 @@ management:
     web:
       exposure:
         include: [ "*", "openapi", "swagger-ui" ]
-    enabled-by-default: true
+    access:
+      default: unrestricted
 
 springdoc:
   show-login-endpoint: true
@@ -88,6 +89,7 @@ vempain:
     max-age: 3600
   original-root-directory: override-me
   export-root-directory: override-me
+  export-file-type: jpeg
   service:
     admin-backend-url: override-me
     admin-backend-username: override-me

--- a/service/src/test/resources/application.yaml
+++ b/service/src/test/resources/application.yaml
@@ -16,6 +16,7 @@ vempain:
     admin-backend-password: vempain-admin-password
   original-root-directory: /var/tmp
   export-root-directory: /var/tmp
+  export-file-type: jpeg
   cors:
     allowed-origins: "${vempain.app.frontend-url},http://localhost:8081"
     cors-pattern: '/**'


### PR DESCRIPTION
This pull request introduces several improvements and refactoring changes across the API and service layers, focusing on file group management, security, and file publishing. The most significant updates include enhanced OpenAPI documentation, stricter security requirements for file group endpoints, improved file export and ingest handling, and codebase organization through package renaming.

**API Documentation and Security Enhancements:**

* Updated the `@OpenAPIDefinition` in `VempainServiceApiDefinition.java` to clarify the service title and make the server port configurable via `${server.port}`.
* Added `@SecurityRequirement(name = "Bearer Authentication")` to `getFileGroups` and `getFileGroupById` endpoints in `FileGroupAPI`, enforcing authentication for these API calls. [[1]](diffhunk://#diff-1280e537cbe685aca09ead947e3a0b4b9bd8b5a4001519a3a5d88675ac9a2a6cR36) [[2]](diffhunk://#diff-1280e537cbe685aca09ead947e3a0b4b9bd8b5a4001519a3a5d88675ac9a2a6cR50)

**Codebase Refactoring and Organization:**

* Renamed the `FileGroupAPI` interface from the `api` package to the `rest` package, and updated all relevant imports in controller and service classes to reflect this change. [[1]](diffhunk://#diff-1280e537cbe685aca09ead947e3a0b4b9bd8b5a4001519a3a5d88675ac9a2a6cL1-R1) [[2]](diffhunk://#diff-c31b46ce6ac16ba7cde146f2adec6219917da2d6bcd5a6356e6e38eb6326e8b6L3-R4)

**File Export and Ingest Improvements:**

* Introduced a new configuration property `export-file-type` (default: `jpeg`) in `application.yaml`, and updated the file publishing logic in `PublishService` to use this type for image exports and file naming. Also removed the redundant `getExtension` method. [[1]](diffhunk://#diff-5c7e087351d3e0d23c05bdde77bc132cae5e2c09412131f33acd5f1e4ba79df8R92) [[2]](diffhunk://#diff-ad472af8cb3e135d965758fbea5f4c684bf698725edec2043fd3e97c23f01b14R40-R42) [[3]](diffhunk://#diff-ad472af8cb3e135d965758fbea5f4c684bf698725edec2043fd3e97c23f01b14L75-R104) [[4]](diffhunk://#diff-ad472af8cb3e135d965758fbea5f4c684bf698725edec2043fd3e97c23f01b14L151-L161)
* Changed the ingest request in `VempainAdminService` to serialize the request as a JSON string using Jackson before sending, ensuring compatibility with the admin backend API. [[1]](diffhunk://#diff-decf546537ca9c4c868bfa9cb8850846f0bf350f0bea796c9a92bd553e21f6c2R3-R4) [[2]](diffhunk://#diff-decf546537ca9c4c868bfa9cb8850846f0bf350f0bea796c9a92bd553e21f6c2L23-R37)

**Other Notable Changes:**

* Updated the `FileGroupResponse` class to use snake_case JSON serialization for consistency with API clients. [[1]](diffhunk://#diff-32a047b05701976a2a8d92b4d90a129785b6a66eaeae14bf107026be9b3789ceR3-R4) [[2]](diffhunk://#diff-32a047b05701976a2a8d92b4d90a129785b6a66eaeae14bf107026be9b3789ceR18)
* Upgraded the dependency version for `vempainAdminVersion` from `0.9.24` to `0.9.25` in `gradle.properties`.
* Adjusted SpringDoc and management endpoint configuration for more flexible access control.