### PR TITLE
Use kabab-case for JWT application variables

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,8 +14,8 @@ services:
       - spring.site-datasource.url=jdbc:postgresql://${ENV_VEMPAIN_SITE_DB_ADDRESS}:5432/${ENV_VEMPAIN_SITE_DB_NAME}?useSSL=false
       - spring.site-datasource.username=${ENV_VEMPAIN_SITE_DB_USER}
       - spring.site-datasource.password=${ENV_VEMPAIN_SITE_DB_PASSWORD}
-      - vempain.app.jwtSecret=your_jwt_secret_here
-      - vempain.app.jwtExpirationMs=86400000
+      - vempain.app.jwt-secret=your_jwt_secret_here
+      - vempain.app.jwt-expiration-ms=86400000
       - vempain.test=false
       - vempain.admin.file.converted-directory=/vempain_admin/converted
       - vempain.admin.ssh.user=${ENV_VEMPAIN_SITE_SSH_USER}
@@ -56,8 +56,8 @@ services:
       - spring.datasource.url=jdbc:postgresql://pg-file:5432/${ENV_VEMPAIN_FILE_DB_NAME}?useSSL=false
       - spring.datasource.username=${ENV_VEMPAIN_FILE_DB_NAME}
       - spring.datasource.password=${ENV_VEMPAIN_FILE_DB_PASSWORD}
-      - vempain.app.jwtSecret=your_jwt_secret_here
-      - vempain.app.jwtExpirationMs=86400000
+      - vempain.app.jwt-secret=your_jwt_secret_here
+      - vempain.app.jwt-expiration-ms=86400000
       - vempain.test=false
       - vempain.admin.file.converted-directory=/vempain_admin/converted
       - vempain.admin.ssh.user=${ENV_VEMPAIN_SITE_SSH_USER}

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,6 @@ jacksonVersion=2.19.2
 # https://mvnrepository.com/artifact/org.junit/junit-bom
 junitVersion=5.13.4
 # https://github.com/Vempain/vempain-auth/packages/2614500
-vempainAuthVersion=0.9.8
+vempainAuthVersion=0.9.9
 # https://github.com/Vempain/vempain-admin-backend/packages/2624185
-vempainAdminVersion=0.9.25
+vempainAdminVersion=0.9.27

--- a/service/src/main/java/fi/poltsi/vempain/file/SetupVerification.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/SetupVerification.java
@@ -33,9 +33,12 @@ class SetupVerification implements ApplicationContextAware {
 
 	private final String[][] requiredKeys = {
 			{"vempain.app.frontend-url", TYPE_STRING},
+			{"vempain.app.jwt-secret", TYPE_STRING},
 			{"vempain.original-root-directory", TYPE_PATH},
 			{"vempain.export-root-directory", TYPE_PATH},
-			{"vempain.service.admin-backend-url", TYPE_STRING}
+			{"vempain.service.admin-backend-url", TYPE_STRING},
+			{"vempain.service.admin-backend-username", TYPE_STRING},
+			{"vempain.service.admin-backend-password", TYPE_STRING}
 	};
 
 	private ApplicationContext applicationContext;

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -80,8 +80,8 @@ vempain:
   license-url: "https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
   app:
     frontend-url: override-me
-    jwtSecret: override-me
-    jwtExpirationMs: 86400000
+    jwt-secret: override-me
+    jwt-expiration-ms: 86400000
   test: true
   cors:
     allowed-origins: ${vempain.app.frontend-url}

--- a/service/src/test/resources/application.yaml
+++ b/service/src/test/resources/application.yaml
@@ -8,8 +8,8 @@ spring:
 vempain:
   app:
     frontend-url: http://localhost:3000
-    jwtSecret: some_secret_key
-    jwtExpirationMs: 86400000
+    jwt-secret: some_secret_key
+    jwt-expiration-ms: 86400000
   service:
     admin-backend-url: http://localhost:9090
     admin-backend-username: vempain-admin


### PR DESCRIPTION
This pull request focuses on standardizing configuration key names related to JWT settings across the codebase and updating dependency versions. The main changes include renaming JWT-related environment variables and configuration keys to use kebab-case, updating required configuration keys, and bumping versions for dependencies.

**Configuration standardization:**

* Renamed all JWT-related keys from camelCase (`jwtSecret`, `jwtExpirationMs`) to kebab-case (`jwt-secret`, `jwt-expiration-ms`) in `docker-compose.yaml`, `service/src/main/resources/application.yaml`, and `service/src/test/resources/application.yaml` for consistency. [[1]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L17-R18) [[2]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L59-R60) [[3]](diffhunk://#diff-5c7e087351d3e0d23c05bdde77bc132cae5e2c09412131f33acd5f1e4ba79df8L83-R84) [[4]](diffhunk://#diff-8edd3889fce22c30e4e4b5e5355ce0b5adfd3abb2835981c806a9ac074d26a49L11-R12)

* Updated the list of required configuration keys in `SetupVerification.java` to use the new `jwt-secret` key and added new required keys for admin backend credentials (`admin-backend-username`, `admin-backend-password`).

**Dependency updates:**

* Bumped `vempainAuthVersion` from `0.9.8` to `0.9.9` and `vempainAdminVersion` from `0.9.25` to `0.9.27` in `gradle.properties`.