### PR TITLE
Add more parsing patterns for datetimes in metadata

### DIFF
--- a/service/src/main/java/fi/poltsi/vempain/file/service/FileScannerService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/FileScannerService.java
@@ -752,18 +752,21 @@ public class FileScannerService {
 		metadataRepository.saveAll(metadataEntities);
 	}
 
-	private Instant dateTimeParser(String dateTimeString) {
+	protected Instant dateTimeParser(String dateTimeString) {
 		if (dateTimeString == null || dateTimeString.isBlank()) {
 			return null;
 		}
 
 		var formatter = new DateTimeFormatterBuilder()
-				// Try: yyyy:MM:dd HH:mm:ss.SSS[S...] (allows up to 9 digits)
+				// Date
 				.appendPattern("yyyy:MM:dd HH:mm:ss")
-				.appendPattern("[yyyy:MM:dd HH:mm:ss[.SSS][.SS][.S]][XXX]")
+				// Optional fractional seconds (from 1 to 9 digits)
 				.optionalStart()
-				.appendLiteral('.')
-				.appendFraction(ChronoField.NANO_OF_SECOND, 1, 9, false)
+				.appendFraction(ChronoField.NANO_OF_SECOND, 1, 9, true)
+				.optionalEnd()
+				// Optional offset like +02:00
+				.optionalStart()
+				.appendOffset("+HH:mm", "Z")
 				.optionalEnd()
 				.toFormatter()
 				.withZone(ZoneId.systemDefault());

--- a/service/src/main/java/fi/poltsi/vempain/file/tools/MetadataTool.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/tools/MetadataTool.java
@@ -112,6 +112,11 @@ public class MetadataTool {
 		locations.put(SUBIFD_KEY, List.of(BITS_PER_SAMPLE_FIELD));
 		locations.put(IFD0_KEY, List.of(BITS_PER_SAMPLE_FIELD));
 		var tagValue = extractJsonString(jsonObject, locations);
+
+		if (tagValue == null) {
+			log.warn("No BitsPerSample found in metadata, returning default 8");
+			return 8;
+		}
 		// The result might be a space separated list of values, we take the first one
 		log.info("Image color depth output: {}", tagValue);
 		// If the output is like "8 8 8", we take the first value

--- a/service/src/test/java/fi/poltsi/vempain/file/service/FileScannerServiceUTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/service/FileScannerServiceUTC.java
@@ -1,0 +1,27 @@
+package fi.poltsi.vempain.file.service;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(MockitoExtension.class)
+class FileScannerServiceUTC {
+
+	@InjectMocks
+	private FileScannerService fileScannerService;
+
+	@ParameterizedTest
+	@CsvSource({
+			"2006:11:19 00:04:34+02:00",
+			"2008:03:20 21:14:46.00+02:00",
+			"2014:06:24 09:34:01.761+03:00",
+	})
+	void dateTimeParser(String dateTimeString) {
+		var dateTime = fileScannerService.dateTimeParser(dateTimeString);
+		assertNotNull(dateTime);
+	}
+}


### PR DESCRIPTION
This pull request improves error handling and logging in both the date/time parsing logic and image metadata extraction. The main changes are focused on making the code more robust against malformed input and providing clearer diagnostics in the logs.

**Error handling and logging improvements:**

* Added a try-catch block to the `dateTimeParser` method in `FileScannerService.java` to catch `DateTimeParseException`, log parsing failures, and return `null` instead of throwing an exception. Also logs successful parsing attempts for better traceability.
* Enhanced the extraction of image color depth in `MetadataTool.java` by adding a check for missing `BitsPerSample` metadata. If not found, it logs a warning and returns a default value of 8 instead of failing.

**Date/time parsing logic:**

* Updated the date/time formatter in `FileScannerService.java` to support more flexible patterns, including optional sub-second precision and timezone offsets. [[1]](diffhunk://#diff-1dd94aa1b6e777cdaf9a2b6b7b3f4be2f8898b0c10922a0bb84b27d1e8df3088R57) [[2]](diffhunk://#diff-1dd94aa1b6e777cdaf9a2b6b7b3f4be2f8898b0c10922a0bb84b27d1e8df3088R763-R778)