### PR TITLE
Improve metadata handling

### DIFF
--- a/service/src/main/java/fi/poltsi/vempain/file/service/FileScannerService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/FileScannerService.java
@@ -388,17 +388,17 @@ public class FileScannerService {
 			}
 			case VIDEO -> {
 				var videoFile = (VideoFileEntity) fileEntity;
-				var res       = MetadataTool.extractVideoResolution(file);
+				var res = MetadataTool.extractXYResolution(file);
 				videoFile.setWidth(res.width);
 				videoFile.setHeight(res.height);
 				videoFile.setFrameRate(MetadataTool.extractFrameRate(file));
-				videoFile.setDuration(MetadataTool.extractVideoDuration(file));
+				videoFile.setDuration(MetadataTool.extractAudioVideoDuration(file));
 				videoFile.setCodec(MetadataTool.extractVideoCodec(file));
 				fileRepository.save(videoFile);
 			}
 			case AUDIO -> {
 				var audioFile = (AudioFileEntity) fileEntity;
-				audioFile.setDuration(MetadataTool.extractAudioDuration(file));
+				audioFile.setDuration(MetadataTool.extractAudioVideoDuration(file));
 				audioFile.setBitRate(MetadataTool.extractAudioBitRate(file));
 				audioFile.setSampleRate(MetadataTool.extractAudioSampleRate(file));
 				audioFile.setCodec(MetadataTool.extractAudioCodec(file));
@@ -413,7 +413,7 @@ public class FileScannerService {
 			}
 			case VECTOR -> {
 				var vectorFile = (VectorFileEntity) fileEntity;
-				var res        = MetadataTool.extractVectorResolution(file);
+				var res = MetadataTool.extractXYResolution(file);
 				vectorFile.setWidth(res.width);
 				vectorFile.setHeight(res.height);
 				vectorFile.setLayersCount(MetadataTool.extractVectorLayersCount(file));
@@ -421,7 +421,7 @@ public class FileScannerService {
 			}
 			case ICON -> {
 				var iconFile = (IconFileEntity) fileEntity;
-				var res      = MetadataTool.extractIconResolution(file);
+				var res = MetadataTool.extractXYResolution(file);
 				iconFile.setWidth(res.width);
 				iconFile.setHeight(res.height);
 				iconFile.setIsScalable(MetadataTool.extractIconIsScalable(file));

--- a/service/src/main/java/fi/poltsi/vempain/file/tools/MetadataTool.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/tools/MetadataTool.java
@@ -111,20 +111,32 @@ public class MetadataTool {
 		Map<String, List<String>> locations = new HashMap<>();
 		locations.put(SUBIFD_KEY, List.of(BITS_PER_SAMPLE_FIELD));
 		locations.put(IFD0_KEY, List.of(BITS_PER_SAMPLE_FIELD));
-		var tagValue = extractJsonString(jsonObject, locations);
 
-		if (tagValue == null) {
-			log.warn("No BitsPerSample found in metadata, returning default 8");
-			return 8;
-		}
-		// The result might be a space separated list of values, we take the first one
-		log.info("Image color depth output: {}", tagValue);
-		// If the output is like "8 8 8", we take the first value
-		if (tagValue.contains(" ")) {
-			tagValue = tagValue.split(" ")[0];
+		var colorDepthNumber = extractJsonNumber(jsonObject, locations);
+
+		if (colorDepthNumber != null) {
+			return colorDepthNumber.intValue();
 		}
 
-		return Integer.parseInt(tagValue);
+		// Let's try to extract it as a string, as sometimes it might be stored as a triplet
+		var colorDepthString = extractJsonString(jsonObject, locations);
+
+		if (colorDepthString != null) {
+			// The result might be a space separated list of values, we take the first one
+			log.info("Image color depth output: {}", colorDepthString);
+			// If the output is like "8 8 8", we take the first value
+			if (colorDepthString.contains(" ")) {
+				colorDepthString = colorDepthString.split(" ")[0];
+			}
+
+			try {
+				return Integer.parseInt(colorDepthString);
+			} catch (Exception e) {
+				log.error("Failed to parse color depth from string: {}", colorDepthString, e);
+			}
+		}
+
+		return 8;
 	}
 
 	public static int extractImageDpi(JSONObject jsonObject) throws IOException {
@@ -140,21 +152,9 @@ public class MetadataTool {
 		return tagValue.intValue();
 	}
 
-	public static Dimension extractVideoResolution(File file) throws IOException {
-		var output = runExifTool(file, "-ImageWidth", "-ImageHeight");
-		var width  = Integer.parseInt(getTagValue(output, "ImageWidth"));
-		var height = Integer.parseInt(getTagValue(output, "ImageHeight"));
-		return new Dimension(width, height);
-	}
-
 	public static double extractFrameRate(File file) throws IOException {
 		var output = runExifTool(file, "-VideoFrameRate");
 		return Double.parseDouble(getTagValue(output, "VideoFrameRate"));
-	}
-
-	public static double extractVideoDuration(File file) throws IOException {
-		var output = runExifTool(file, "-Duration");
-		return Double.parseDouble(getTagValue(output, "Duration"));
 	}
 
 	public static String extractVideoCodec(File file) throws IOException {
@@ -162,7 +162,7 @@ public class MetadataTool {
 		return getTagValue(output, "VideoCodec");
 	}
 
-	public static double extractAudioDuration(File file) throws IOException {
+	public static double extractAudioVideoDuration(File file) throws IOException {
 		var output = runExifTool(file, "-Duration");
 		return Double.parseDouble(getTagValue(output, "Duration"));
 	}
@@ -197,19 +197,12 @@ public class MetadataTool {
 		return getTagValue(output, "FileType");
 	}
 
-	public static Dimension extractVectorResolution(File file) throws IOException {
-		var output = runExifTool(file, "-ImageWidth", "-ImageHeight");
-		var width  = Integer.parseInt(getTagValue(output, "ImageWidth"));
-		var height = Integer.parseInt(getTagValue(output, "ImageHeight"));
-		return new Dimension(width, height);
-	}
-
 	public static int extractVectorLayersCount(File file) throws IOException {
 		var output = runExifTool(file, "-Layers");
 		return Integer.parseInt(getTagValue(output, "Layers"));
 	}
 
-	public static Dimension extractIconResolution(File file) throws IOException {
+	public static Dimension extractXYResolution(File file) throws IOException {
 		var output = runExifTool(file, "-ImageWidth", "-ImageHeight");
 		var width  = Integer.parseInt(getTagValue(output, "ImageWidth"));
 		var height = Integer.parseInt(getTagValue(output, "ImageHeight"));

--- a/service/src/main/java/fi/poltsi/vempain/file/tools/MetadataTool.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/tools/MetadataTool.java
@@ -107,6 +107,13 @@ public class MetadataTool {
 		return null;
 	}
 
+	/**
+	 * Extract the image color depth from the given metadata in JSON format
+	 *
+	 * @param jsonObject Extracted JSON formatted metadata (from @MetadataTools.getMetadataAsJSON())
+	 * @return int value retrieved, or 8 if none were found or parsing failed. 8 is a good default for most images.
+	 * @throws IOException If an error occurs during extraction
+	 */
 	public static int extractImageColorDepth(JSONObject jsonObject) throws IOException {
 		Map<String, List<String>> locations = new HashMap<>();
 		locations.put(SUBIFD_KEY, List.of(BITS_PER_SAMPLE_FIELD));


### PR DESCRIPTION
This pull request refactors how file resolutions and durations are extracted throughout the codebase, consolidating similar logic and improving robustness in metadata parsing. The main changes include replacing several specialized resolution extraction methods with a single unified method, generalizing duration extraction, and making color depth parsing more resilient to different metadata formats.

**Refactoring and Consolidation of Metadata Extraction:**

* Replaced specialized methods `extractVideoResolution`, `extractVectorResolution`, and `extractIconResolution` with a single unified method `extractXYResolution` in `MetadataTool`, simplifying resolution extraction for video, vector, and icon files. (`service/src/main/java/fi/poltsi/vempain/file/tools/MetadataTool.java`, `service/src/main/java/fi/poltsi/vempain/file/service/FileScannerService.java`) [[1]](diffhunk://#diff-1dd94aa1b6e777cdaf9a2b6b7b3f4be2f8898b0c10922a0bb84b27d1e8df3088L391-R401) [[2]](diffhunk://#diff-1dd94aa1b6e777cdaf9a2b6b7b3f4be2f8898b0c10922a0bb84b27d1e8df3088L416-R424) [[3]](diffhunk://#diff-5d0a525acce043c1391da9c9cfd0fb6fcc557c434be66f8218f369ecd2482649L143-R165) [[4]](diffhunk://#diff-5d0a525acce043c1391da9c9cfd0fb6fcc557c434be66f8218f369ecd2482649L200-R205)

* Consolidated audio and video duration extraction into a single method `extractAudioVideoDuration`, replacing the previous separate `extractAudioDuration` and `extractVideoDuration` methods. This reduces code duplication and ensures consistent handling of duration metadata. (`service/src/main/java/fi/poltsi/vempain/file/tools/MetadataTool.java`, `service/src/main/java/fi/poltsi/vempain/file/service/FileScannerService.java`) [[1]](diffhunk://#diff-1dd94aa1b6e777cdaf9a2b6b7b3f4be2f8898b0c10922a0bb84b27d1e8df3088L391-R401) [[2]](diffhunk://#diff-5d0a525acce043c1391da9c9cfd0fb6fcc557c434be66f8218f369ecd2482649L143-R165)

**Improved Metadata Parsing Robustness:**

* Enhanced the `extractImageColorDepth` method to handle both numeric and string representations of color depth, including cases where the value is a space-separated triplet. This change improves resilience against varying metadata formats and prevents parsing errors. (`service/src/main/java/fi/poltsi/vempain/file/tools/MetadataTool.java`)

**Generalization and Cleanup:**

* Removed redundant methods for extracting resolutions and durations, reducing the overall codebase complexity and maintenance overhead. (`service/src/main/java/fi/poltsi/vempain/file/tools/MetadataTool.java`) [[1]](diffhunk://#diff-5d0a525acce043c1391da9c9cfd0fb6fcc557c434be66f8218f369ecd2482649L143-R165) [[2]](diffhunk://#diff-5d0a525acce043c1391da9c9cfd0fb6fcc557c434be66f8218f369ecd2482649L200-R205)