### PR TITLE
Run code cleanup on the whole code base

### DIFF
--- a/service/src/main/java/fi/poltsi/vempain/file/service/DerivativeLookupService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/DerivativeLookupService.java
@@ -21,11 +21,10 @@ import java.util.Objects;
 @Slf4j
 @Service
 public class DerivativeLookupService {
-	@Value("${vempain.export-root-directory}")
-	private String exportDirectory;
-
 	private final ExportFileRepository exportFileRepository;
 	private final FileRepository       fileRepository;
+	@Value("${vempain.export-root-directory}")
+	private String exportDirectory;
 
 	public File findOriginal(String subPath, String filename, String documentId) {
 		var baseName = stripExtension(filename);

--- a/service/src/main/java/fi/poltsi/vempain/file/service/PublishService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/PublishService.java
@@ -81,7 +81,7 @@ public class PublishService {
 					imageTool.resizeImage(exportFilePath, tempFile, siteImageSize, 0.7f);
 					tempPathToDelete = tempFile;
 					exportFilePath = tempFile;
-					uploadPath = tempFile;
+					uploadPath     = tempFile;
 
 					// We need to also update the siteFileName to replace the original extension with
 					int suffixIndex = siteFileName.lastIndexOf('.');

--- a/service/src/main/java/fi/poltsi/vempain/file/tools/ImageTool.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/tools/ImageTool.java
@@ -25,9 +25,9 @@ public class ImageTool {
 		// Get the original dimensions of the source file in order to see whether it should be resized
 		var origDimensions   = getImageDimensions(sourceFile);
 		var targetDimensions = new Dimension();
-		var imageFormat      = destinationFile.toString()
-											  .substring(destinationFile.toString()
-																		.lastIndexOf(".") + 1);
+		var imageFormat = destinationFile.toString()
+										 .substring(destinationFile.toString()
+																   .lastIndexOf(".") + 1);
 
 		// If the original image is smaller than the minimum size, just copy it
 		if (origDimensions.height < imageMinimumSize || origDimensions.width < imageMinimumSize) {


### PR DESCRIPTION
This pull request makes a minor change to the `DerivativeLookupService` class, reordering the declaration of the `exportDirectory` field to follow the constructor-injected repository fields. No functional changes were introduced.