### PR TITLE
More GPS data handling fixes

### DIFF
--- a/service/src/main/java/fi/poltsi/vempain/file/service/DirectoryProcessorService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/DirectoryProcessorService.java
@@ -530,7 +530,15 @@ public class DirectoryProcessorService {
 				gpsData.getLongitudeRef());
 
 		if (optionalExistingGps.isEmpty()) {
-			gpsData = gpsLocationRepository.save(gpsData);
+			// Make sure the non-null fields are not null
+			if (gpsData.getLatitude() == null
+				|| gpsData.getLatitudeRef() == null
+				|| gpsData.getLongitude() == null
+				|| gpsData.getLongitudeRef() == null) {
+				log.warn("GPS data not containing required fields, cannot save GPS data for file: {}", gpsData);
+			} else {
+				gpsData = gpsLocationRepository.save(gpsData);
+			}
 		} else {
 			var existingGps    = optionalExistingGps.get();
 			var updateExisting = false;


### PR DESCRIPTION
This pull request introduces an important validation step to ensure GPS data integrity before saving new GPS entries. The change adds a check to confirm that all required GPS fields are present and logs a warning if any are missing, preventing incomplete GPS data from being saved.

Validation and error handling:

* Added a conditional check in `createFileEntity` (in `DirectoryProcessorService.java`) to verify that `gpsData` contains non-null values for latitude, latitude reference, longitude, and longitude reference before saving; logs a warning and skips saving if any required field is missing.