### PR TITLE
If retrieving satellite count fails as string, try getting it as number

### DIFF
--- a/service/src/main/java/fi/poltsi/vempain/file/tools/MetadataTool.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/tools/MetadataTool.java
@@ -576,13 +576,22 @@ public class MetadataTool {
 		locations = new HashMap<>();
 		locations.put(GPS_KEY, List.of("GPSSatellites"));
 
-		var satelliteString = extractJsonString(jsonObject, locations);
-		if (satelliteString != null && !satelliteString.isBlank()) {
-			try {
-				var satelliteCount = Integer.parseInt(satelliteString.trim());
-				gpsLocationEntity.setSatelliteCount(satelliteCount);
-			} catch (NumberFormatException e) {
-				log.error("Failed to parse GPS satellite count: {}", satelliteString, e);
+		try {
+			var satelliteString = extractJsonString(jsonObject, locations);
+			if (satelliteString != null && !satelliteString.isBlank()) {
+				try {
+					var satelliteCount = Integer.parseInt(satelliteString.trim());
+					gpsLocationEntity.setSatelliteCount(satelliteCount);
+				} catch (NumberFormatException e) {
+					log.error("Failed to parse GPS satellite count: {}", satelliteString, e);
+				}
+			}
+		} catch (JSONException e) {
+			log.warn("Failed to parse GPS satellite count as string. Attempting to get number instead");
+			var satelliteCount = extractJsonNumber(jsonObject, locations);
+
+			if (satelliteCount != null) {
+				gpsLocationEntity.setSatelliteCount(satelliteCount.intValue());
 			}
 		}
 


### PR DESCRIPTION
This pull request improves the robustness of GPS metadata extraction in the `MetadataTool` by handling cases where the GPS satellite count is stored as a number instead of a string. The main change is the addition of error handling to support both formats.

**GPS Satellite Count Extraction Improvements:**

* Wrapped the extraction of the GPS satellite count string in a try-catch block to handle `JSONException` and log a warning if parsing as a string fails.
* Added fallback logic to extract the satellite count as a number if string extraction fails, ensuring the value is set correctly on `gpsLocationEntity`.