### PR TITLE
Better exception handling when extracting color depth

### DIFF
--- a/service/src/main/java/fi/poltsi/vempain/file/service/DirectoryProcessorService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/DirectoryProcessorService.java
@@ -256,7 +256,7 @@ public class DirectoryProcessorService {
 		var fileEntity = createFileEntity(fileType, file, fileGroup, mimetype, jsonObject, metadata, relativeFilePath);
 
 		if (fileEntity == null) {
-			log.error("Failed to create file entity for file: {}", file.getName());
+			log.warn("Can not create file entity for file: {}", file.getName());
 			return Boolean.FALSE;
 		}
 
@@ -587,7 +587,8 @@ public class DirectoryProcessorService {
 			var existingFile = fileRepository.findByOriginalDocumentId(originalDocumentId);
 
 			if (existingFile != null) {
-				log.warn("File with the same original document ID already exists in the database: {} for file: {}", originalDocumentId, file.getName());
+				log.warn("File with the same original document ID already exists in the database: {} as file file: {} / {}", originalDocumentId,
+						 existingFile.getFilePath(), existingFile.getFilename());
 				return null;
 			}
 		}

--- a/service/src/main/java/fi/poltsi/vempain/file/tools/MetadataTool.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/tools/MetadataTool.java
@@ -131,9 +131,23 @@ public class MetadataTool {
 		var locations = new HashMap<String, List<String>>();
 		locations.put(SUBIFD_KEY, List.of(BITS_PER_SAMPLE_FIELD));
 		locations.put(IFD0_KEY, List.of(BITS_PER_SAMPLE_FIELD));
-
+		String colorDepthString = null;
 		// Let's try to extract it as a string, as sometimes it might be stored as a triplet
-		var colorDepthString = extractJsonString(jsonObject, locations);
+		try {
+			colorDepthString = extractJsonString(jsonObject, locations);
+		} catch (JSONException e) {
+			log.warn("Failed to parse color depth as string. Attempting to get number instead");
+
+			try {
+				var colorDepthNumber = extractJsonNumber(jsonObject, locations);
+				if (colorDepthNumber != null) {
+					return colorDepthNumber.intValue();
+				}
+			} catch (JSONException e1) {
+				log.warn("Failed to parse color depth as number so returning default. Exception: {}", e1.getMessage());
+				return 8;
+			}
+		}
 
 		if (colorDepthString != null) {
 			// Match any triplet format like "8 8 8" or "8, 8, 8" or "16 16 16"


### PR DESCRIPTION
This pull request improves error handling and logging in the file processing and metadata extraction logic. The main changes are focused on making log messages clearer and ensuring graceful fallback when parsing image color depth metadata.

**Logging improvements:**

* Changed log level from error to warning when a file entity cannot be created, to better reflect non-critical issues in `DirectoryProcessorService.java`.
* Enhanced duplicate file logging to include both file path and filename for easier identification of existing files.

**Metadata extraction robustness:**

* Improved the `extractImageColorDepth` method in `MetadataTool.java` to handle exceptions when parsing color depth as a string, and added a fallback to parse as a number or return a default value if both methods fail. Log messages were added for each failure scenario to aid debugging.