### PR TITLE
Update dependency packages to latest

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -39,7 +39,6 @@ dependencies {
 	api "org.springframework.boot:spring-boot-starter-webmvc:${springBootVersion}"
 	api "org.springframework.boot:spring-boot-starter-jackson:${springBootVersion}"
 	api "org.springframework.boot:spring-boot-starter-validation:${springBootVersion}"
-	api "org.springframework.data:spring-data-jpa:${springBootVersion}"
 	// This needs to be built first in vempain-auth
 	api "fi.poltsi.vempain:vempain-auth-api:${vempainAuthVersion}"
 	implementation "io.swagger.core.v3:swagger-annotations:${swaggerVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,24 +1,24 @@
 releaseVersion=0.0.1-SNAPSHOT
 javaVersion=25
 # https://mvnrepository.com/artifact/org.springframework.boot/spring-boot
-springBootVersion=4.0.2
+springBootVersion=4.0.5
 # https://mvnrepository.com/artifact/org.testcontainers/testcontainers
-testContainersVersion=2.0.3
+testContainersVersion=2.0.4
 # https://mvnrepository.com/artifact/io.freefair.lombok/io.freefair.lombok.gradle.plugin
 ioFreeFairLombok=9.2.0
 # https://mvnrepository.com/artifact/org.json/json
 jsonVersion=20251224
 # https://mvnrepository.com/artifact/org.postgresql/postgresql
-postgresqlVersion=42.7.9
+postgresqlVersion=42.7.10
 # https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api
 jjwtVersion=0.13.0
 # https://mvnrepository.com/artifact/org.junit/junit-bom
-junitVersion=6.0.2
+junitVersion=6.0.3
 # https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-annotations
-swaggerVersion=2.2.42
+swaggerVersion=2.2.45
 # https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter
-mockitoVersion=5.21.0
+mockitoVersion=5.23.0
 # https://github.com/Vempain/vempain-auth/packages/2723219
-vempainAuthVersion=1.0.3
+vempainAuthVersion=1.0.5
 # https://github.com/Vempain/vempain-admin-backend/packages/2624185
-vempainAdminVersion=1.0.6
+vempainAdminVersion=1.0.13

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,6 @@ swaggerVersion=2.2.45
 # https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter
 mockitoVersion=5.23.0
 # https://github.com/Vempain/vempain-auth/packages/2723219
-vempainAuthVersion=1.0.5
+vempainAuthVersion=1.0.6
 # https://github.com/Vempain/vempain-admin-backend/packages/2624185
 vempainAdminVersion=1.0.13

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -63,7 +63,7 @@ dependencies {
 	developmentOnly "org.springframework.boot:spring-boot-docker-compose:${springBootVersion}"
 	implementation "io.jsonwebtoken:jjwt-api:${jjwtVersion}"
 	// https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui
-	implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1"
+	implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2"
 	// https://mvnrepository.com/artifact/jakarta.xml.bind/jakarta.xml.bind-api
 	implementation "jakarta.xml.bind:jakarta.xml.bind-api:4.0.5"
 	// https://mvnrepository.com/artifact/jakarta.annotation/jakarta.annotation-api


### PR DESCRIPTION
This pull request primarily updates several dependencies to their latest versions across the project and removes an unused dependency from the API module. These changes help keep the codebase up-to-date with security patches and new features, and also clean up unnecessary dependencies.

Dependency version updates:

* Updated multiple dependency versions in `gradle.properties`, including `springBootVersion`, `testContainersVersion`, `postgresqlVersion`, `jjwtVersion`, `junitVersion`, `swaggerVersion`, `mockitoVersion`, `vempainAuthVersion`, and `vempainAdminVersion` to their latest releases.
* Updated `org.springdoc:springdoc-openapi-starter-webmvc-ui` from version `3.0.1` to `3.0.2` in `service/build.gradle`.

Dependency cleanup:

* Removed the `spring-data-jpa` dependency from the API module in `api/build.gradle`, as it is no longer needed.