### PR TITLE
Use proper paging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,71 @@
+# vempain-file-backend — Agent Guide
+
+## Architecture
+
+Two-module Gradle project (Java 25, Spring Boot 4.0.5):
+
+| Module     | Purpose                                                                             |
+|------------|-------------------------------------------------------------------------------------|
+| `api/`     | REST API interfaces, request/response DTOs — published as a JAR consumed by clients |
+| `service/` | Spring Boot application: JPA entities, repositories, services, controllers          |
+
+Authentication primitives (`AbstractVempainEntity`, `PagedRequest`, `PagedResponse`) come from the external library `fi.poltsi.vempain:vempain-auth-api`.
+
+## Build & Run
+
+```bash
+./gradlew compileJava           # compile only
+./gradlew build                 # compile + test
+./gradlew clean test            # clean + integration tests (needs Docker DB)
+./docker_db.sh                  # start local PostgreSQL container
+```
+
+Tests require `exiftool` installed on the host. GitHub Package Registry credentials must be set via `gpr.user`/`gpr.token` in `~/.gradle/gradle.properties` or
+`GITHUB_ACTOR`/`GITHUB_TOKEN` env vars.
+
+## File-Type Hierarchy
+
+13 typed file categories, each a JPA entity that extends `FileEntity` (JOINED table inheritance):
+
+`archive · audio · binary · data · document · executable · font · icon · image · interactive · thumb · vector · video`
+
+- Base entity: `service/src/main/java/fi/poltsi/vempain/file/entity/FileEntity.java`
+- Common searchable fields: `filename`, `filePath`, `description`, `mimetype`
+- Entity → DTO: call `entity.toResponse()` (implemented in every typed entity)
+
+## Paged List Pattern (canonical)
+
+All `findAll` endpoints use **POST** to `<BASE_PATH>/paged` with a `@RequestBody PagedRequest`.
+
+Reference implementation: `FileGroupAPI.java` / `FileGroupController.java` / `FileGroupService.java`.
+
+For typed file endpoints:
+
+1. **API interface** (`api/.../rest/files/XxxFileAPI.java`) — `@PostMapping(BASE_PATH + "/paged")` accepting `@Valid @RequestBody PagedRequest`
+2. **Repository** (`service/.../repository/files/XxxFileRepository.java`) — extends `JpaRepository<Entity, Long>, JpaSpecificationExecutor<Entity>`
+3. **Service** (`service/.../service/files/XxxFileService.java`) — use `FileSearchHelper.buildSpecification(search, caseSensitive)` and
+   `FileSearchHelper.buildSort(sortBy, direction)` from `FileSearchHelper.java`
+4. **Controller** — delegates straight to the service with the `PagedRequest`
+
+For complex native-SQL search (e.g. across joined tables), follow `FileGroupRepositoryImpl.java`.
+
+## Adding a New File Type
+
+1. Create entity extending `FileEntity` in `service/.../entity/`
+2. Create repository extending `JpaRepository<E, Long>, JpaSpecificationExecutor<E>`
+3. Create service using `FileSearchHelper`; expose `findAll(PagedRequest)`, `findById(long)`, `delete(long)`
+4. Create API interface in `api/.../rest/files/` with `POST /paged`, `GET /{id}`, `DELETE /{id}`
+5. Create controller in `service/.../controller/files/` implementing the API interface
+
+## Key Conventions
+
+- JSON field names use snake_case (`@JsonNaming(SnakeCaseStrategy.class)` in DTOs)
+- Test class suffix `ITC` = integration test, `UTC` = unit test
+- Schema managed by Flyway; migrations under `service/src/main/resources/db/migration/`
+- `FileGroupRepositoryImpl` uses raw native SQL — keep column names in sync with Flyway scripts
+
+## Further Reading
+
+See [`docs/AGENTS.md`](docs/AGENTS.md) for deep-dive on GPS/location privacy guards, the publish pipeline, Feign client integrations, and scan/metadata
+extraction flow.
+

--- a/api/src/main/java/fi/poltsi/vempain/file/api/request/ScanRequest.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/api/request/ScanRequest.java
@@ -21,7 +21,7 @@ public class ScanRequest {
 
 	@Nullable
 	@Size.List({
-			@Size(min = 2, message = "String length must be at least 2 characters"),
+			@Size(min = 1, message = "String length must be at least 1 characters"),
 			@Size(max = 4096, message = "String length must be at most 4096 characters")
 	})
 	@Pattern(message = "Directory name must start with a slash and contain only valid characters",
@@ -33,7 +33,7 @@ public class ScanRequest {
 
 	@Nullable
 	@Size.List({
-			@Size(min = 2, message = "String length must be at least 2 characters"),
+			@Size(min = 1, message = "String length must be at least 1 characters"),
 			@Size(max = 4096, message = "String length must be at most 4096 characters")
 	})
 	@Pattern(message = "Directory name must start with a slash and contain only valid characters",

--- a/api/src/main/java/fi/poltsi/vempain/file/rest/files/ArchiveFileAPI.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/rest/files/ArchiveFileAPI.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.rest.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.ArchiveFileResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,33 +9,29 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Archive file API", description = "API for accessing and managing archive files")
 public interface ArchiveFileAPI {
 	String BASE_PATH = "/files/archive";
 
-	@Operation(summary = "Get all archive files", description = "Retrieve archive files with paging", tags = "Archive file API")
-	@Parameter(name = "page", description = "Page number (0-based)", example = "0")
-	@Parameter(name = "size", description = "Number of items per page", example = "50")
+	@Operation(summary = "Get all archive files", description = "Retrieve archive files with paging, sorting and search", tags = "Archive file API")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "Page of archive files retrieved successfully"),
+			@ApiResponse(responseCode = "400", description = "Invalid request"),
 			@ApiResponse(responseCode = "403", description = "Unauthorized access"),
 			@ApiResponse(responseCode = "500", description = "Internal server error")
 	})
 	@SecurityRequirement(name = "Bearer Authentication")
-	@GetMapping(path = BASE_PATH, produces = MediaType.APPLICATION_JSON_VALUE)
-	ResponseEntity<PagedResponse<ArchiveFileResponse>> findAll(
-			@RequestParam(name = "page", defaultValue = "0") @PositiveOrZero int page,
-			@RequestParam(name = "size", defaultValue = "50") @Positive int size
-	);
+	@PostMapping(path = BASE_PATH + "/paged", produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<PagedResponse<ArchiveFileResponse>> findAll(@Valid @RequestBody PagedRequest pagedRequest);
 
 	@Operation(summary = "Get archive file by ID", description = "Retrieve specific archive file by its unique identifier", tags = "Archive file API")
 	@Parameter(name = "id", description = "Archive ID to be fetched", example = "1")

--- a/api/src/main/java/fi/poltsi/vempain/file/rest/files/AudioFileAPI.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/rest/files/AudioFileAPI.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.rest.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.AudioFileResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,33 +9,29 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Audio file API", description = "API for accessing and managing audio files")
 public interface AudioFileAPI {
 	String BASE_PATH = "/files/audio";
 
-	@Operation(summary = "Get all audio files", description = "Retrieve audio files with paging", tags = "Audio file API")
-	@Parameter(name = "page", description = "Page number (0-based)", example = "0")
-	@Parameter(name = "size", description = "Number of items per page", example = "50")
+	@Operation(summary = "Get all audio files", description = "Retrieve audio files with paging, sorting and search", tags = "Audio file API")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "Page of audio files retrieved successfully"),
+			@ApiResponse(responseCode = "400", description = "Invalid request"),
 			@ApiResponse(responseCode = "403", description = "Unauthorized access"),
 			@ApiResponse(responseCode = "500", description = "Internal server error")
 	})
 	@SecurityRequirement(name = "Bearer Authentication")
-	@GetMapping(path = BASE_PATH, produces = MediaType.APPLICATION_JSON_VALUE)
-	ResponseEntity<PagedResponse<AudioFileResponse>> findAll(
-			@RequestParam(name = "page", defaultValue = "0") @PositiveOrZero int page,
-			@RequestParam(name = "size", defaultValue = "50") @Positive int size
-	);
+	@PostMapping(path = BASE_PATH + "/paged", produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<PagedResponse<AudioFileResponse>> findAll(@Valid @RequestBody PagedRequest pagedRequest);
 
 	@Operation(summary = "Get audio file by ID", description = "Retrieve specific audio file by its unique identifier", tags = "Audio file API")
 	@Parameter(name = "id", description = "Audio ID to be fetched", example = "1")

--- a/api/src/main/java/fi/poltsi/vempain/file/rest/files/BinaryFileAPI.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/rest/files/BinaryFileAPI.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.rest.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.BinaryFileResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,33 +9,29 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Binary file API", description = "API for accessing and managing binary files")
 public interface BinaryFileAPI {
 	String BASE_PATH = "/files/binary";
 
-	@Operation(summary = "Get all binary files", description = "Retrieve binary files with paging", tags = "Binary file API")
-	@Parameter(name = "page", description = "Page number (0-based)", example = "0")
-	@Parameter(name = "size", description = "Number of items per page", example = "50")
+	@Operation(summary = "Get all binary files", description = "Retrieve binary files with paging, sorting and search", tags = "Binary file API")
 	@ApiResponses({
 			@ApiResponse(responseCode = "200", description = "Page of binary files retrieved successfully"),
+			@ApiResponse(responseCode = "400", description = "Invalid request"),
 			@ApiResponse(responseCode = "403", description = "Unauthorized access"),
 			@ApiResponse(responseCode = "500", description = "Internal server error")
 	})
 	@SecurityRequirement(name = "Bearer Authentication")
-	@GetMapping(path = BASE_PATH, produces = MediaType.APPLICATION_JSON_VALUE)
-	ResponseEntity<PagedResponse<BinaryFileResponse>> findAll(
-			@RequestParam(name = "page", defaultValue = "0") @PositiveOrZero int page,
-			@RequestParam(name = "size", defaultValue = "50") @Positive int size
-	);
+	@PostMapping(path = BASE_PATH + "/paged", produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<PagedResponse<BinaryFileResponse>> findAll(@Valid @RequestBody PagedRequest pagedRequest);
 
 	@Operation(summary = "Get binary file by ID", description = "Retrieve specific binary file by its unique identifier", tags = "Binary file API")
 	@Parameter(name = "id", description = "Binary file ID", example = "1")

--- a/api/src/main/java/fi/poltsi/vempain/file/rest/files/DataFileAPI.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/rest/files/DataFileAPI.java
@@ -1,39 +1,35 @@
 package fi.poltsi.vempain.file.rest.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.DataFileResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Data file API", description = "API for accessing and managing data files")
 public interface DataFileAPI {
 	String BASE_PATH = "/files/data";
 
-	@Operation(summary = "Get all data files", description = "Retrieve data files with paging", tags = "Data file API")
-	@Parameter(name = "page", description = "Page number (0-based)", example = "0")
-	@Parameter(name = "size", description = "Number of items per page", example = "50")
+	@Operation(summary = "Get all data files", description = "Retrieve data files with paging, sorting and search", tags = "Data file API")
 	@ApiResponses({
 			@ApiResponse(responseCode = "200", description = "Page of data files retrieved successfully"),
+			@ApiResponse(responseCode = "400", description = "Invalid request"),
 			@ApiResponse(responseCode = "403", description = "Unauthorized access")
 	})
 	@SecurityRequirement(name = "Bearer Authentication")
-	@GetMapping(path = BASE_PATH, produces = MediaType.APPLICATION_JSON_VALUE)
-	ResponseEntity<PagedResponse<DataFileResponse>> findAll(
-			@RequestParam(name = "page", defaultValue = "0") @PositiveOrZero int page,
-			@RequestParam(name = "size", defaultValue = "50") @Positive int size
-	);
+	@PostMapping(path = BASE_PATH + "/paged", produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<PagedResponse<DataFileResponse>> findAll(@Valid @RequestBody PagedRequest pagedRequest);
 
 	@Operation(summary = "Get data file by ID", description = "Retrieve specific data file by ID", tags = "Data file API")
 	@ApiResponses({
@@ -55,4 +51,3 @@ public interface DataFileAPI {
 	@DeleteMapping(BASE_PATH + "/{id}")
 	ResponseEntity<Void> delete(@PathVariable("id") long id);
 }
-

--- a/api/src/main/java/fi/poltsi/vempain/file/rest/files/DocumentFileAPI.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/rest/files/DocumentFileAPI.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.rest.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.DocumentFileResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,33 +9,29 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Document file API", description = "API for accessing and managing document files")
 public interface DocumentFileAPI {
 	String BASE_PATH = "/files/document";
 
-	@Operation(summary = "Get all document files", description = "Retrieve of document files with paging", tags = "Document file API")
-	@Parameter(name = "page", description = "Page number (0-based)", example = "0")
-	@Parameter(name = "size", description = "Number of items per page", example = "50")
+	@Operation(summary = "Get all document files", description = "Retrieve document files with paging, sorting and search", tags = "Document file API")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "Page of document files retrieved successfully"),
+			@ApiResponse(responseCode = "400", description = "Invalid request"),
 			@ApiResponse(responseCode = "403", description = "Unauthorized access"),
 			@ApiResponse(responseCode = "500", description = "Internal server error")
 	})
 	@SecurityRequirement(name = "Bearer Authentication")
-	@GetMapping(path = BASE_PATH, produces = MediaType.APPLICATION_JSON_VALUE)
-	ResponseEntity<PagedResponse<DocumentFileResponse>> findAll(
-			@RequestParam(name = "page", defaultValue = "0") @PositiveOrZero int page,
-			@RequestParam(name = "size", defaultValue = "50") @Positive int size
-	);
+	@PostMapping(path = BASE_PATH + "/paged", produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<PagedResponse<DocumentFileResponse>> findAll(@Valid @RequestBody PagedRequest pagedRequest);
 
 	@Operation(summary = "Get document file by ID", description = "Retrieve specific document file by its unique identifier", tags = "Document file API")
 	@Parameter(name = "id", description = "Document ID to be fetched", example = "1")

--- a/api/src/main/java/fi/poltsi/vempain/file/rest/files/ExecutableFileAPI.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/rest/files/ExecutableFileAPI.java
@@ -1,39 +1,35 @@
 package fi.poltsi.vempain.file.rest.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.ExecutableFileResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Executable file API", description = "API for accessing and managing executable files")
 public interface ExecutableFileAPI {
 	String BASE_PATH = "/files/executable";
 
-	@Operation(summary = "Get all executable files", description = "Retrieve executable files with paging", tags = "Executable file API")
-	@Parameter(name = "page", description = "Page number (0-based)", example = "0")
-	@Parameter(name = "size", description = "Items per page", example = "50")
+	@Operation(summary = "Get all executable files", description = "Retrieve executable files with paging, sorting and search", tags = "Executable file API")
 	@ApiResponses({
-			@ApiResponse(responseCode = "200", description = "Page retrieved"),
+			@ApiResponse(responseCode = "200", description = "Page retrieved successfully"),
+			@ApiResponse(responseCode = "400", description = "Invalid request"),
 			@ApiResponse(responseCode = "403", description = "Unauthorized")
 	})
 	@SecurityRequirement(name = "Bearer Authentication")
-	@GetMapping(path = BASE_PATH, produces = MediaType.APPLICATION_JSON_VALUE)
-	ResponseEntity<PagedResponse<ExecutableFileResponse>> findAll(
-			@RequestParam(name = "page", defaultValue = "0") @PositiveOrZero int page,
-			@RequestParam(name = "size", defaultValue = "50") @Positive int size
-	);
+	@PostMapping(path = BASE_PATH + "/paged", produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<PagedResponse<ExecutableFileResponse>> findAll(@Valid @RequestBody PagedRequest pagedRequest);
 
 	@Operation(summary = "Get executable file by ID", description = "Retrieve executable file by ID", tags = "Executable file API")
 	@ApiResponses({

--- a/api/src/main/java/fi/poltsi/vempain/file/rest/files/FontFileAPI.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/rest/files/FontFileAPI.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.rest.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.FontFileResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,33 +9,29 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Font file API", description = "API for accessing and managing font files")
 public interface FontFileAPI {
 	String BASE_PATH = "/files/font";
 
-	@Operation(summary = "Get all font files", description = "Retrieve of font files with paging", tags = "Font file API")
-	@Parameter(name = "page", description = "Page number (0-based)", example = "0")
-	@Parameter(name = "size", description = "Number of items per page", example = "50")
+	@Operation(summary = "Get all font files", description = "Retrieve font files with paging, sorting and search", tags = "Font file API")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "Page of font files retrieved successfully"),
+			@ApiResponse(responseCode = "400", description = "Invalid request"),
 			@ApiResponse(responseCode = "403", description = "Unauthorized access"),
 			@ApiResponse(responseCode = "500", description = "Internal server error")
 	})
 	@SecurityRequirement(name = "Bearer Authentication")
-	@GetMapping(path = BASE_PATH, produces = MediaType.APPLICATION_JSON_VALUE)
-	ResponseEntity<PagedResponse<FontFileResponse>> findAll(
-			@RequestParam(name = "page", defaultValue = "0") @PositiveOrZero int page,
-			@RequestParam(name = "size", defaultValue = "50") @Positive int size
-	);
+	@PostMapping(path = BASE_PATH + "/paged", produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<PagedResponse<FontFileResponse>> findAll(@Valid @RequestBody PagedRequest pagedRequest);
 
 	@Operation(summary = "Get font file by ID", description = "Retrieve specific font file by its unique identifier", tags = "Font file API")
 	@Parameter(name = "id", description = "Font ID to be fetched", example = "1")

--- a/api/src/main/java/fi/poltsi/vempain/file/rest/files/IconFileAPI.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/rest/files/IconFileAPI.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.rest.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.IconFileResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,33 +9,29 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Icon file API", description = "API for accessing and managing icon files")
 public interface IconFileAPI {
 	String BASE_PATH = "/files/icon";
 
-	@Operation(summary = "Get all icon files", description = "Retrieve of icon files with paging", tags = "Icon file API")
-	@Parameter(name = "page", description = "Page number (0-based)", example = "0")
-	@Parameter(name = "size", description = "Number of items per page", example = "50")
+	@Operation(summary = "Get all icon files", description = "Retrieve icon files with paging, sorting and search", tags = "Icon file API")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "Page of icon files retrieved successfully"),
+			@ApiResponse(responseCode = "400", description = "Invalid request"),
 			@ApiResponse(responseCode = "403", description = "Unauthorized access"),
 			@ApiResponse(responseCode = "500", description = "Internal server error")
 	})
 	@SecurityRequirement(name = "Bearer Authentication")
-	@GetMapping(path = BASE_PATH, produces = MediaType.APPLICATION_JSON_VALUE)
-	ResponseEntity<PagedResponse<IconFileResponse>> findAll(
-			@RequestParam(name = "page", defaultValue = "0") @PositiveOrZero int page,
-			@RequestParam(name = "size", defaultValue = "50") @Positive int size
-	);
+	@PostMapping(path = BASE_PATH + "/paged", produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<PagedResponse<IconFileResponse>> findAll(@Valid @RequestBody PagedRequest pagedRequest);
 
 	@Operation(summary = "Get icon file by ID", description = "Retrieve specific icon file by its unique identifier", tags = "Icon file API")
 	@Parameter(name = "id", description = "Icon ID to be fetched", example = "1")

--- a/api/src/main/java/fi/poltsi/vempain/file/rest/files/ImageFileAPI.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/rest/files/ImageFileAPI.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.rest.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.ImageFileResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,33 +9,29 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Image file API", description = "API for accessing and managing image files")
 public interface ImageFileAPI {
 	String BASE_PATH = "/files/image";
 
-	@Operation(summary = "Get image files (paged)", description = "Retrieve image files with paging", tags = "Image file API")
-	@Parameter(name = "page", description = "Page number (0-based)", example = "0")
-	@Parameter(name = "size", description = "Number of items per page", example = "50")
+	@Operation(summary = "Get all image files", description = "Retrieve image files with paging, sorting and search", tags = "Image file API")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "Page of image files retrieved successfully"),
+			@ApiResponse(responseCode = "400", description = "Invalid request"),
 			@ApiResponse(responseCode = "403", description = "Unauthorized access"),
 			@ApiResponse(responseCode = "500", description = "Internal server error")
 	})
 	@SecurityRequirement(name = "Bearer Authentication")
-	@GetMapping(path = BASE_PATH, produces = MediaType.APPLICATION_JSON_VALUE)
-	ResponseEntity<PagedResponse<ImageFileResponse>> findAll(
-			@RequestParam(name = "page", defaultValue = "0") @PositiveOrZero int page,
-			@RequestParam(name = "size", defaultValue = "50") @Positive int size
-	);
+	@PostMapping(path = BASE_PATH + "/paged", produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<PagedResponse<ImageFileResponse>> findAll(@Valid @RequestBody PagedRequest pagedRequest);
 
 	@Operation(summary = "Get image file by ID", description = "Retrieve specific image file by its unique identifier", tags = "Image file API")
 	@Parameter(name = "id", description = "Image ID to be fetched", example = "1")

--- a/api/src/main/java/fi/poltsi/vempain/file/rest/files/InteractiveFileAPI.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/rest/files/InteractiveFileAPI.java
@@ -1,40 +1,39 @@
 package fi.poltsi.vempain.file.rest.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.InteractiveFileResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Interactive file API", description = "API for accessing and managing interactive files")
 public interface InteractiveFileAPI {
 
 	String BASE_PATH = "/files/interactive";
 
-	@Operation(summary = "Get all interactive files", description = "Retrieve paged interactive files")
-	@Parameter(name = "page", description = "0-based page number", example = "0")
-	@Parameter(name = "size", description = "Page size", example = "50")
-	@ApiResponses({
-			@ApiResponse(responseCode = "200", description = "Interactive files page retrieved"),
-			@ApiResponse(responseCode = "403", description = "Forbidden")
+	@Operation(summary = "Get all interactive file files",
+	           description = "Retrieve interactive file files with paging, sorting and search",
+	           tags = "Interactive file API")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Page of interactive file files retrieved successfully"),
+			@ApiResponse(responseCode = "400", description = "Invalid request"),
+			@ApiResponse(responseCode = "403", description = "Unauthorized access"),
+			@ApiResponse(responseCode = "500", description = "Internal server error")
 	})
 	@SecurityRequirement(name = "Bearer Authentication")
-	@GetMapping(path = BASE_PATH, produces = MediaType.APPLICATION_JSON_VALUE)
-	ResponseEntity<PagedResponse<InteractiveFileResponse>> findAll(
-			@RequestParam(name = "page", defaultValue = "0") @PositiveOrZero int page,
-			@RequestParam(name = "size", defaultValue = "50") @Positive int size
-	);
+	@PostMapping(path = BASE_PATH + "/paged", produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<PagedResponse<InteractiveFileResponse>> findAll(@Valid @RequestBody PagedRequest pagedRequest);
 
 	@Operation(summary = "Get interactive file by id")
 	@ApiResponses({

--- a/api/src/main/java/fi/poltsi/vempain/file/rest/files/ThumbFileAPI.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/rest/files/ThumbFileAPI.java
@@ -1,40 +1,37 @@
 package fi.poltsi.vempain.file.rest.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.ThumbFileResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Thumb file API", description = "API for accessing and managing thumbnail files")
 public interface ThumbFileAPI {
 
 	String BASE_PATH = "/files/thumb";
 
-	@Operation(summary = "Get all thumbnail files", description = "Retrieve paged thumbnail files")
-	@Parameter(name = "page", description = "0-based page number", example = "0")
-	@Parameter(name = "size", description = "Page size", example = "50")
-	@ApiResponses({
-			@ApiResponse(responseCode = "200", description = "Thumbnail files page retrieved"),
-			@ApiResponse(responseCode = "403", description = "Forbidden")
+	@Operation(summary = "Get all thumb file files", description = "Retrieve thumb file files with paging, sorting and search", tags = "Thumb file API")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Page of thumb file files retrieved successfully"),
+			@ApiResponse(responseCode = "400", description = "Invalid request"),
+			@ApiResponse(responseCode = "403", description = "Unauthorized access"),
+			@ApiResponse(responseCode = "500", description = "Internal server error")
 	})
 	@SecurityRequirement(name = "Bearer Authentication")
-	@GetMapping(path = BASE_PATH, produces = MediaType.APPLICATION_JSON_VALUE)
-	ResponseEntity<PagedResponse<ThumbFileResponse>> findAll(
-			@RequestParam(name = "page", defaultValue = "0") @PositiveOrZero int page,
-			@RequestParam(name = "size", defaultValue = "50") @Positive int size
-	);
+	@PostMapping(path = BASE_PATH + "/paged", produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<PagedResponse<ThumbFileResponse>> findAll(@Valid @RequestBody PagedRequest pagedRequest);
 
 	@Operation(summary = "Get thumbnail file by id")
 	@ApiResponses({

--- a/api/src/main/java/fi/poltsi/vempain/file/rest/files/VectorFileAPI.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/rest/files/VectorFileAPI.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.rest.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.VectorFileResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,33 +9,29 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Vector file API", description = "API for accessing and managing vector files")
 public interface VectorFileAPI {
 	String BASE_PATH = "/files/vector";
 
-	@Operation(summary = "Get all vector files", description = "Retrieve vector files with paging", tags = "Vector file API")
-	@Parameter(name = "page", description = "Page number (0-based)", example = "0")
-	@Parameter(name = "size", description = "Number of items per page", example = "50")
+	@Operation(summary = "Get all vector files", description = "Retrieve vector files with paging, sorting and search", tags = "Vector file API")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "Page of vector files retrieved successfully"),
+			@ApiResponse(responseCode = "400", description = "Invalid request"),
 			@ApiResponse(responseCode = "403", description = "Unauthorized access"),
 			@ApiResponse(responseCode = "500", description = "Internal server error")
 	})
 	@SecurityRequirement(name = "Bearer Authentication")
-	@GetMapping(path = BASE_PATH, produces = MediaType.APPLICATION_JSON_VALUE)
-	ResponseEntity<PagedResponse<VectorFileResponse>> findAll(
-			@RequestParam(name = "page", defaultValue = "0") @PositiveOrZero int page,
-			@RequestParam(name = "size", defaultValue = "50") @Positive int size
-	);
+	@PostMapping(path = BASE_PATH + "/paged", produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<PagedResponse<VectorFileResponse>> findAll(@Valid @RequestBody PagedRequest pagedRequest);
 
 	@Operation(summary = "Get vector file by ID", description = "Retrieve specific vector file by its unique identifier", tags = "Vector file API")
 	@Parameter(name = "id", description = "Vector ID to be removed", example = "1")

--- a/api/src/main/java/fi/poltsi/vempain/file/rest/files/VideoFileAPI.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/rest/files/VideoFileAPI.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.rest.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.VideoFileResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,33 +9,29 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Video file API", description = "API for accessing and managing video files")
 public interface VideoFileAPI {
 	String BASE_PATH = "/files/video";
 
-	@Operation(summary = "Get all video files", description = "Retrieve video files with paging", tags = "Video file API")
-	@Parameter(name = "page", description = "Page number (0-based)", example = "0")
-	@Parameter(name = "size", description = "Number of items per page", example = "50")
+	@Operation(summary = "Get all video files", description = "Retrieve video files with paging, sorting and search", tags = "Video file API")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "Page of video files retrieved successfully"),
+			@ApiResponse(responseCode = "400", description = "Invalid request"),
 			@ApiResponse(responseCode = "403", description = "Unauthorized access"),
 			@ApiResponse(responseCode = "500", description = "Internal server error")
 	})
 	@SecurityRequirement(name = "Bearer Authentication")
-	@GetMapping(path = BASE_PATH, produces = MediaType.APPLICATION_JSON_VALUE)
-	ResponseEntity<PagedResponse<VideoFileResponse>> findAll(
-			@RequestParam(name = "page", defaultValue = "0") @PositiveOrZero int page,
-			@RequestParam(name = "size", defaultValue = "50") @Positive int size
-	);
+	@PostMapping(path = BASE_PATH + "/paged", produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<PagedResponse<VideoFileResponse>> findAll(@Valid @RequestBody PagedRequest pagedRequest);
 
 	@Operation(summary = "Get video file by ID", description = "Retrieve specific video file by its unique identifier", tags = "Video file API")
 	@Parameter(name = "id", description = "Video ID to be removed", example = "1")

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -5,6 +5,7 @@ plugins {
 	id 'org.springframework.boot' version "${springBootVersion}"
 	id "io.freefair.lombok" version "${ioFreeFairLombok}"
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'jacoco'
 }
 
 group = 'fi.poltsi.vempain'
@@ -98,6 +99,30 @@ dependencyManagement {
 
 test {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+	dependsOn test
+	reports {
+		xml.required = true
+		html.required = true
+	}
+}
+
+jacocoTestCoverageVerification {
+	dependsOn test
+	violationRules {
+		rule {
+			element = 'PACKAGE'
+			includes = ['fi.poltsi.vempain.file.service.files']
+			limit {
+				counter = 'LINE'
+				value = 'COVEREDRATIO'
+				minimum = 0.95
+			}
+		}
+	}
 }
 
 processResources {

--- a/service/src/main/java/fi/poltsi/vempain/file/SetupVerification.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/SetupVerification.java
@@ -1,6 +1,7 @@
 package fi.poltsi.vempain.file;
 
 import lombok.AllArgsConstructor;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.springframework.beans.BeansException;
@@ -13,7 +14,6 @@ import org.springframework.core.env.AbstractEnvironment;
 import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.MutablePropertySources;
-import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
 import java.nio.file.Files;

--- a/service/src/main/java/fi/poltsi/vempain/file/controller/files/ArchiveFileController.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/controller/files/ArchiveFileController.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.controller.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.ArchiveFileResponse;
 import fi.poltsi.vempain.file.rest.files.ArchiveFileAPI;
@@ -15,8 +16,8 @@ public class ArchiveFileController implements ArchiveFileAPI {
 	private final ArchiveFileService archiveFileService;
 
 	@Override
-	public ResponseEntity<PagedResponse<ArchiveFileResponse>> findAll(int page, int size) {
-		return ResponseEntity.ok(archiveFileService.findAll(page, size));
+	public ResponseEntity<PagedResponse<ArchiveFileResponse>> findAll(PagedRequest pagedRequest) {
+		return ResponseEntity.ok(archiveFileService.findAll(pagedRequest));
 	}
 
 	@Override

--- a/service/src/main/java/fi/poltsi/vempain/file/controller/files/AudioFileController.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/controller/files/AudioFileController.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.controller.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.AudioFileResponse;
 import fi.poltsi.vempain.file.rest.files.AudioFileAPI;
@@ -15,8 +16,8 @@ public class AudioFileController implements AudioFileAPI {
 	private final AudioFileService audioFileService;
 
 	@Override
-	public ResponseEntity<PagedResponse<AudioFileResponse>> findAll(int page, int size) {
-		return ResponseEntity.ok(audioFileService.findAll(page, size));
+	public ResponseEntity<PagedResponse<AudioFileResponse>> findAll(PagedRequest pagedRequest) {
+		return ResponseEntity.ok(audioFileService.findAll(pagedRequest));
 	}
 
 	@Override

--- a/service/src/main/java/fi/poltsi/vempain/file/controller/files/BinaryFileController.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/controller/files/BinaryFileController.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.controller.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.BinaryFileResponse;
 import fi.poltsi.vempain.file.rest.files.BinaryFileAPI;
@@ -15,8 +16,8 @@ public class BinaryFileController implements BinaryFileAPI {
 	private final BinaryFileService service;
 
 	@Override
-	public ResponseEntity<PagedResponse<BinaryFileResponse>> findAll(int page, int size) {
-		return ResponseEntity.ok(service.findAll(page, size));
+	public ResponseEntity<PagedResponse<BinaryFileResponse>> findAll(PagedRequest pagedRequest) {
+		return ResponseEntity.ok(service.findAll(pagedRequest));
 	}
 
 	@Override

--- a/service/src/main/java/fi/poltsi/vempain/file/controller/files/DataFileController.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/controller/files/DataFileController.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.controller.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.DataFileResponse;
 import fi.poltsi.vempain.file.rest.files.DataFileAPI;
@@ -15,8 +16,8 @@ public class DataFileController implements DataFileAPI {
 	private final DataFileService service;
 
 	@Override
-	public ResponseEntity<PagedResponse<DataFileResponse>> findAll(int page, int size) {
-		return ResponseEntity.ok(service.findAll(page, size));
+	public ResponseEntity<PagedResponse<DataFileResponse>> findAll(PagedRequest pagedRequest) {
+		return ResponseEntity.ok(service.findAll(pagedRequest));
 	}
 
 	@Override

--- a/service/src/main/java/fi/poltsi/vempain/file/controller/files/DocumentFileController.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/controller/files/DocumentFileController.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.controller.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.DocumentFileResponse;
 import fi.poltsi.vempain.file.rest.files.DocumentFileAPI;
@@ -15,8 +16,8 @@ public class DocumentFileController implements DocumentFileAPI {
 	private final DocumentFileService documentFileService;
 
 	@Override
-	public ResponseEntity<PagedResponse<DocumentFileResponse>> findAll(int page, int size) {
-		return ResponseEntity.ok(documentFileService.findAll(page, size));
+	public ResponseEntity<PagedResponse<DocumentFileResponse>> findAll(PagedRequest pagedRequest) {
+		return ResponseEntity.ok(documentFileService.findAll(pagedRequest));
 	}
 
 	@Override

--- a/service/src/main/java/fi/poltsi/vempain/file/controller/files/ExecutableFileController.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/controller/files/ExecutableFileController.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.controller.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.ExecutableFileResponse;
 import fi.poltsi.vempain.file.rest.files.ExecutableFileAPI;
@@ -15,8 +16,8 @@ public class ExecutableFileController implements ExecutableFileAPI {
 	private final ExecutableFileService service;
 
 	@Override
-	public ResponseEntity<PagedResponse<ExecutableFileResponse>> findAll(int page, int size) {
-		return ResponseEntity.ok(service.findAll(page, size));
+	public ResponseEntity<PagedResponse<ExecutableFileResponse>> findAll(PagedRequest pagedRequest) {
+		return ResponseEntity.ok(service.findAll(pagedRequest));
 	}
 
 	@Override

--- a/service/src/main/java/fi/poltsi/vempain/file/controller/files/FontFileController.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/controller/files/FontFileController.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.controller.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.FontFileResponse;
 import fi.poltsi.vempain.file.rest.files.FontFileAPI;
@@ -15,8 +16,8 @@ public class FontFileController implements FontFileAPI {
 	private final FontFileService fontFileService;
 
 	@Override
-	public ResponseEntity<PagedResponse<FontFileResponse>> findAll(int page, int size) {
-		return ResponseEntity.ok(fontFileService.findAll(page, size));
+	public ResponseEntity<PagedResponse<FontFileResponse>> findAll(PagedRequest pagedRequest) {
+		return ResponseEntity.ok(fontFileService.findAll(pagedRequest));
 	}
 
 	@Override

--- a/service/src/main/java/fi/poltsi/vempain/file/controller/files/IconFileController.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/controller/files/IconFileController.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.controller.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.IconFileResponse;
 import fi.poltsi.vempain.file.rest.files.IconFileAPI;
@@ -15,8 +16,8 @@ public class IconFileController implements IconFileAPI {
 	private final IconFileService iconFileService;
 
 	@Override
-	public ResponseEntity<PagedResponse<IconFileResponse>> findAll(int page, int size) {
-		return ResponseEntity.ok(iconFileService.findAll(page, size));
+	public ResponseEntity<PagedResponse<IconFileResponse>> findAll(PagedRequest pagedRequest) {
+		return ResponseEntity.ok(iconFileService.findAll(pagedRequest));
 	}
 
 	@Override

--- a/service/src/main/java/fi/poltsi/vempain/file/controller/files/ImageFileController.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/controller/files/ImageFileController.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.controller.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.ImageFileResponse;
 import fi.poltsi.vempain.file.rest.files.ImageFileAPI;
@@ -15,8 +16,8 @@ public class ImageFileController implements ImageFileAPI {
 	private final ImageFileService imageFileService;
 
 	@Override
-	public ResponseEntity<PagedResponse<ImageFileResponse>> findAll(int page, int size) {
-		return ResponseEntity.ok(imageFileService.findAll(page, size));
+	public ResponseEntity<PagedResponse<ImageFileResponse>> findAll(PagedRequest pagedRequest) {
+		return ResponseEntity.ok(imageFileService.findAll(pagedRequest));
 	}
 
 	@Override

--- a/service/src/main/java/fi/poltsi/vempain/file/controller/files/InteractiveFileController.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/controller/files/InteractiveFileController.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.controller.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.InteractiveFileResponse;
 import fi.poltsi.vempain.file.rest.files.InteractiveFileAPI;
@@ -15,8 +16,8 @@ public class InteractiveFileController implements InteractiveFileAPI {
 	private final InteractiveFileService service;
 
 	@Override
-	public ResponseEntity<PagedResponse<InteractiveFileResponse>> findAll(int page, int size) {
-		return ResponseEntity.ok(service.findAll(page, size));
+	public ResponseEntity<PagedResponse<InteractiveFileResponse>> findAll(PagedRequest pagedRequest) {
+		return ResponseEntity.ok(service.findAll(pagedRequest));
 	}
 
 	@Override

--- a/service/src/main/java/fi/poltsi/vempain/file/controller/files/ThumbFileController.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/controller/files/ThumbFileController.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.controller.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.ThumbFileResponse;
 import fi.poltsi.vempain.file.rest.files.ThumbFileAPI;
@@ -15,8 +16,8 @@ public class ThumbFileController implements ThumbFileAPI {
 	private final ThumbFileService service;
 
 	@Override
-	public ResponseEntity<PagedResponse<ThumbFileResponse>> findAll(int page, int size) {
-		return ResponseEntity.ok(service.findAll(page, size));
+	public ResponseEntity<PagedResponse<ThumbFileResponse>> findAll(PagedRequest pagedRequest) {
+		return ResponseEntity.ok(service.findAll(pagedRequest));
 	}
 
 	@Override

--- a/service/src/main/java/fi/poltsi/vempain/file/controller/files/VectorFileController.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/controller/files/VectorFileController.java
@@ -1,6 +1,7 @@
 package fi.poltsi.vempain.file.controller.files;
 
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.VectorFileResponse;
 import fi.poltsi.vempain.file.rest.files.VectorFileAPI;
@@ -16,8 +17,8 @@ public class VectorFileController implements VectorFileAPI {
 	private final VectorFileService vectorFileService;
 
 	@Override
-	public ResponseEntity<PagedResponse<VectorFileResponse>> findAll(int page, int size) {
-		return ResponseEntity.ok(vectorFileService.findAll(page, size));
+	public ResponseEntity<PagedResponse<VectorFileResponse>> findAll(PagedRequest pagedRequest) {
+		return ResponseEntity.ok(vectorFileService.findAll(pagedRequest));
 	}
 
 	@Override

--- a/service/src/main/java/fi/poltsi/vempain/file/controller/files/VideoFileController.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/controller/files/VideoFileController.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.controller.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.VideoFileResponse;
 import fi.poltsi.vempain.file.rest.files.VideoFileAPI;
@@ -15,8 +16,8 @@ public class VideoFileController implements VideoFileAPI {
 	private final VideoFileService videoFileService;
 
 	@Override
-	public ResponseEntity<PagedResponse<VideoFileResponse>> findAll(int page, int size) {
-		return ResponseEntity.ok(videoFileService.findAll(page, size));
+	public ResponseEntity<PagedResponse<VideoFileResponse>> findAll(PagedRequest pagedRequest) {
+		return ResponseEntity.ok(videoFileService.findAll(pagedRequest));
 	}
 
 	@Override

--- a/service/src/main/java/fi/poltsi/vempain/file/exception/GlobalExceptionHandler.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/exception/GlobalExceptionHandler.java
@@ -1,0 +1,37 @@
+package fi.poltsi.vempain.file.exception;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Global exception handler that maps domain exceptions to appropriate HTTP
+ * status codes.
+ *
+ * <ul>
+ *   <li>{@link EntityNotFoundException} → 404 Not Found</li>
+ *   <li>{@link IllegalArgumentException} → 400 Bad Request</li>
+ * </ul>
+ */
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(EntityNotFoundException.class)
+	public ResponseEntity<String> handleEntityNotFound(EntityNotFoundException ex) {
+		log.warn("Entity not found: {}", ex.getMessage());
+		return ResponseEntity.status(HttpStatus.NOT_FOUND)
+		                     .body(ex.getMessage());
+	}
+
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<String> handleIllegalArgument(IllegalArgumentException ex) {
+		log.warn("Illegal argument: {}", ex.getMessage());
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+		                     .body(ex.getMessage());
+	}
+}
+

--- a/service/src/main/java/fi/poltsi/vempain/file/repository/DocumentFileRepository.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/repository/DocumentFileRepository.java
@@ -2,9 +2,10 @@ package fi.poltsi.vempain.file.repository;
 
 import fi.poltsi.vempain.file.entity.DocumentFileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface DocumentFileRepository extends JpaRepository<DocumentFileEntity, Long> {
+public interface DocumentFileRepository extends JpaRepository<DocumentFileEntity, Long>, JpaSpecificationExecutor<DocumentFileEntity> {
 	// Add custom query methods if necessary
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/repository/files/ArchiveFileRepository.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/repository/files/ArchiveFileRepository.java
@@ -2,9 +2,10 @@ package fi.poltsi.vempain.file.repository.files;
 
 import fi.poltsi.vempain.file.entity.ArchiveFileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ArchiveFileRepository extends JpaRepository<ArchiveFileEntity, Long> {
+public interface ArchiveFileRepository extends JpaRepository<ArchiveFileEntity, Long>, JpaSpecificationExecutor<ArchiveFileEntity> {
 	// Add custom query methods if necessary
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/repository/files/AudioFileRepository.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/repository/files/AudioFileRepository.java
@@ -2,9 +2,10 @@ package fi.poltsi.vempain.file.repository.files;
 
 import fi.poltsi.vempain.file.entity.AudioFileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface AudioFileRepository extends JpaRepository<AudioFileEntity, Long> {
+public interface AudioFileRepository extends JpaRepository<AudioFileEntity, Long>, JpaSpecificationExecutor<AudioFileEntity> {
 	// Add custom query methods if necessary
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/repository/files/BinaryFileRepository.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/repository/files/BinaryFileRepository.java
@@ -2,6 +2,7 @@ package fi.poltsi.vempain.file.repository.files;
 
 import fi.poltsi.vempain.file.entity.BinaryFileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -9,6 +10,6 @@ import org.springframework.stereotype.Repository;
  * Provides paging (findAll(Pageable)), lookup (findById) and deletion (deleteById).
  */
 @Repository
-public interface BinaryFileRepository extends JpaRepository<BinaryFileEntity, Long> {
+public interface BinaryFileRepository extends JpaRepository<BinaryFileEntity, Long>, JpaSpecificationExecutor<BinaryFileEntity> {
 	// ...existing code...
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/repository/files/DataFileRepository.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/repository/files/DataFileRepository.java
@@ -2,6 +2,7 @@ package fi.poltsi.vempain.file.repository.files;
 
 import fi.poltsi.vempain.file.entity.DataFileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -9,6 +10,6 @@ import org.springframework.stereotype.Repository;
  * Provides paging (findAll(Pageable)), lookup (findById) and deletion (deleteById).
  */
 @Repository
-public interface DataFileRepository extends JpaRepository<DataFileEntity, Long> {
+public interface DataFileRepository extends JpaRepository<DataFileEntity, Long>, JpaSpecificationExecutor<DataFileEntity> {
 	// ...existing code...
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/repository/files/ExecutableFileRepository.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/repository/files/ExecutableFileRepository.java
@@ -2,6 +2,7 @@ package fi.poltsi.vempain.file.repository.files;
 
 import fi.poltsi.vempain.file.entity.ExecutableFileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -9,6 +10,6 @@ import org.springframework.stereotype.Repository;
  * Provides paging (findAll(Pageable)), lookup (findById) and deletion (deleteById).
  */
 @Repository
-public interface ExecutableFileRepository extends JpaRepository<ExecutableFileEntity, Long> {
+public interface ExecutableFileRepository extends JpaRepository<ExecutableFileEntity, Long>, JpaSpecificationExecutor<ExecutableFileEntity> {
 	// ...existing code...
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/repository/files/FileRepository.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/repository/files/FileRepository.java
@@ -2,12 +2,13 @@ package fi.poltsi.vempain.file.repository.files;
 
 import fi.poltsi.vempain.file.entity.FileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
-public interface FileRepository extends JpaRepository<FileEntity, Long> {
+public interface FileRepository extends JpaRepository<FileEntity, Long>, JpaSpecificationExecutor<FileEntity> {
 	Optional<FileEntity> findByFilePathAndFilename(String filePath, String filename);
 
 	FileEntity findByOriginalDocumentId(String originalDocumentId);

--- a/service/src/main/java/fi/poltsi/vempain/file/repository/files/FontFileRepository.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/repository/files/FontFileRepository.java
@@ -2,9 +2,10 @@ package fi.poltsi.vempain.file.repository.files;
 
 import fi.poltsi.vempain.file.entity.FontFileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface FontFileRepository extends JpaRepository<FontFileEntity, Long> {
+public interface FontFileRepository extends JpaRepository<FontFileEntity, Long>, JpaSpecificationExecutor<FontFileEntity> {
 	// Add custom query methods if necessary
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/repository/files/IconFileRepository.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/repository/files/IconFileRepository.java
@@ -2,9 +2,10 @@ package fi.poltsi.vempain.file.repository.files;
 
 import fi.poltsi.vempain.file.entity.IconFileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface IconFileRepository extends JpaRepository<IconFileEntity, Long> {
+public interface IconFileRepository extends JpaRepository<IconFileEntity, Long>, JpaSpecificationExecutor<IconFileEntity> {
 	// Add custom query methods if necessary
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/repository/files/ImageFileRepository.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/repository/files/ImageFileRepository.java
@@ -2,9 +2,10 @@ package fi.poltsi.vempain.file.repository.files;
 
 import fi.poltsi.vempain.file.entity.ImageFileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ImageFileRepository extends JpaRepository<ImageFileEntity, Long> {
+public interface ImageFileRepository extends JpaRepository<ImageFileEntity, Long>, JpaSpecificationExecutor<ImageFileEntity> {
 	// Add custom query methods if necessary
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/repository/files/InteractiveFileRepository.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/repository/files/InteractiveFileRepository.java
@@ -2,6 +2,7 @@ package fi.poltsi.vempain.file.repository.files;
 
 import fi.poltsi.vempain.file.entity.InteractiveFileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -9,6 +10,6 @@ import org.springframework.stereotype.Repository;
  * Provides paging (findAll(Pageable)), lookup (findById) and deletion (deleteById).
  */
 @Repository
-public interface InteractiveFileRepository extends JpaRepository<InteractiveFileEntity, Long> {
+public interface InteractiveFileRepository extends JpaRepository<InteractiveFileEntity, Long>, JpaSpecificationExecutor<InteractiveFileEntity> {
 	// ...existing code...
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/repository/files/ThumbFileRepository.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/repository/files/ThumbFileRepository.java
@@ -2,6 +2,7 @@ package fi.poltsi.vempain.file.repository.files;
 
 import fi.poltsi.vempain.file.entity.ThumbFileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -9,6 +10,6 @@ import org.springframework.stereotype.Repository;
  * Provides paging (findAll(Pageable)), lookup (findById) and deletion (deleteById).
  */
 @Repository
-public interface ThumbFileRepository extends JpaRepository<ThumbFileEntity, Long> {
+public interface ThumbFileRepository extends JpaRepository<ThumbFileEntity, Long>, JpaSpecificationExecutor<ThumbFileEntity> {
 	// ...existing code...
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/repository/files/VectorFileRepository.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/repository/files/VectorFileRepository.java
@@ -2,9 +2,10 @@ package fi.poltsi.vempain.file.repository.files;
 
 import fi.poltsi.vempain.file.entity.VectorFileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface VectorFileRepository extends JpaRepository<VectorFileEntity, Long> {
+public interface VectorFileRepository extends JpaRepository<VectorFileEntity, Long>, JpaSpecificationExecutor<VectorFileEntity> {
 	// Add custom query methods if necessary
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/repository/files/VideoFileRepository.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/repository/files/VideoFileRepository.java
@@ -2,9 +2,10 @@ package fi.poltsi.vempain.file.repository.files;
 
 import fi.poltsi.vempain.file.entity.VideoFileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface VideoFileRepository extends JpaRepository<VideoFileEntity, Long> {
+public interface VideoFileRepository extends JpaRepository<VideoFileEntity, Long>, JpaSpecificationExecutor<VideoFileEntity> {
 	// Add custom query methods if necessary
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/service/DerivativeLookupService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/DerivativeLookupService.java
@@ -94,12 +94,10 @@ public class DerivativeLookupService {
 				if (xmpSection == null) {
 					return false;
 				}
-				var derived = xmpSection.has("DerivedFromOriginalDocumentID")
-							  ? xmpSection.get("DerivedFromOriginalDocumentID")
-										  .asText() : null;
-				var original = xmpSection.has("OriginalDocumentID")
-							   ? xmpSection.get("OriginalDocumentID")
-										   .asText() : null;
+				var derivedNode  = xmpSection.get("DerivedFromOriginalDocumentID");
+				var originalNode = xmpSection.get("OriginalDocumentID");
+				var derived      = derivedNode != null ? mapper.convertValue(derivedNode, String.class) : null;
+				var original     = originalNode != null ? mapper.convertValue(originalNode, String.class) : null;
 				return Objects.equals(documentId, derived) || Objects.equals(documentId, original);
 			}
 		} catch (Exception e) {

--- a/service/src/main/java/fi/poltsi/vempain/file/service/FileScannerService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/FileScannerService.java
@@ -53,7 +53,7 @@ public class FileScannerService {
 		var failedFiles             = new ArrayList<String>();
 		var successfulFileResponses = new ArrayList<FileResponse>();
 		var leafDirectories         = new ArrayList<Path>();
-		var scanDirectory           = Path.of(originalRootDirectory, selectedDirectory);
+		var scanDirectory = resolveScanDirectory(originalRootDirectory, selectedDirectory);
 
 		success = populateLeafDirectory(leafDirectories, errorMessage, scanDirectory);
 
@@ -83,7 +83,7 @@ public class FileScannerService {
 		var orphanedFiles           = new ArrayList<String>();
 		var successfulFileResponses = new ArrayList<ExportFileResponse>();
 		var leafDirectories         = new ArrayList<Path>();
-		var scanDirectory           = Path.of(exportRootDirectory, exportedDirectory);
+		var scanDirectory = resolveScanDirectory(exportRootDirectory, exportedDirectory);
 
 		success = populateLeafDirectory(leafDirectories, errorMessage, scanDirectory);
 
@@ -118,6 +118,14 @@ public class FileScannerService {
 			log.error("Error checking if directory is leaf: {}", path, e);
 			return false;
 		}
+	}
+
+	private Path resolveScanDirectory(String configuredRoot, String selectedDirectory) {
+		if (selectedDirectory == null || "/".equals(selectedDirectory)) {
+			return Path.of(configuredRoot);
+		}
+		var relativePath = selectedDirectory.startsWith("/") ? selectedDirectory.substring(1) : selectedDirectory;
+		return Path.of(configuredRoot, relativePath);
 	}
 
 	private boolean populateLeafDirectory(ArrayList<Path> leafDirectories, StringBuilder errorMessage, Path scanDirectory) {

--- a/service/src/main/java/fi/poltsi/vempain/file/service/files/ArchiveFileService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/files/ArchiveFileService.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.service.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.ArchiveFileResponse;
 import fi.poltsi.vempain.file.entity.ArchiveFileEntity;
@@ -7,6 +8,7 @@ import fi.poltsi.vempain.file.repository.files.ArchiveFileRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,9 +21,13 @@ public class ArchiveFileService {
 	private final ArchiveFileRepository archiveFileRepository;
 
 	@Transactional(readOnly = true)
-	public PagedResponse<ArchiveFileResponse> findAll(int page, int size) {
-		var pageable   = PageRequest.of(Math.max(0, page), Math.max(1, size));
-		var pageResult = archiveFileRepository.findAll(pageable);
+	public PagedResponse<ArchiveFileResponse> findAll(PagedRequest pagedRequest) {
+		var                              safePage   = Math.max(0, pagedRequest.getPage());
+		var                              safeSize   = Math.min(Math.max(pagedRequest.getSize(), 1), 200);
+		var                              sort       = FileSearchHelper.buildSort(pagedRequest.getSortBy(), pagedRequest.getDirection());
+		Specification<ArchiveFileEntity> spec       = FileSearchHelper.buildSpecification(pagedRequest.getSearch(), Boolean.TRUE.equals(pagedRequest.getCaseSensitive()));
+		var                              pageable   = PageRequest.of(safePage, safeSize, sort);
+		var                              pageResult = archiveFileRepository.findAll(spec, pageable);
 		var content = pageResult.getContent()
 								.stream()
 								.map(ArchiveFileEntity::toResponse)
@@ -45,12 +51,11 @@ public class ArchiveFileService {
 	}
 
 	public HttpStatus delete(long id) {
-		try {
-			archiveFileRepository.deleteById(id);
-			return HttpStatus.OK;
-		} catch (Exception e) {
-			log.warn("Failed to delete archive file with id {}: {}", id, e.getMessage());
+		if (!archiveFileRepository.existsById(id)) {
+			log.warn("Archive file with id {} not found", id);
 			return HttpStatus.NOT_FOUND;
 		}
+		archiveFileRepository.deleteById(id);
+		return HttpStatus.OK;
 	}
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/service/files/AudioFileService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/files/AudioFileService.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.service.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.AudioFileResponse;
 import fi.poltsi.vempain.file.entity.AudioFileEntity;
@@ -7,6 +8,7 @@ import fi.poltsi.vempain.file.repository.files.AudioFileRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,9 +21,13 @@ public class AudioFileService {
 	private final AudioFileRepository audioFileRepository;
 
 	@Transactional(readOnly = true)
-	public PagedResponse<AudioFileResponse> findAll(int page, int size) {
-		var pageable   = PageRequest.of(Math.max(0, page), Math.max(1, size));
-		var pageResult = audioFileRepository.findAll(pageable);
+	public PagedResponse<AudioFileResponse> findAll(PagedRequest pagedRequest) {
+		var                            safePage   = Math.max(0, pagedRequest.getPage());
+		var                            safeSize   = Math.min(Math.max(pagedRequest.getSize(), 1), 200);
+		var                            sort       = FileSearchHelper.buildSort(pagedRequest.getSortBy(), pagedRequest.getDirection());
+		Specification<AudioFileEntity> spec       = FileSearchHelper.buildSpecification(pagedRequest.getSearch(), Boolean.TRUE.equals(pagedRequest.getCaseSensitive()));
+		var                            pageable   = PageRequest.of(safePage, safeSize, sort);
+		var                            pageResult = audioFileRepository.findAll(spec, pageable);
 		var content = pageResult.getContent()
 								.stream()
 								.map(AudioFileEntity::toResponse)
@@ -45,12 +51,11 @@ public class AudioFileService {
 	}
 
 	public HttpStatus delete(long id) {
-		try {
-			audioFileRepository.deleteById(id);
-			return HttpStatus.OK;
-		} catch (Exception e) {
-			log.warn("Failed to delete archive file with id {}: {}", id, e.getMessage());
+		if (!audioFileRepository.existsById(id)) {
+			log.warn("Audio file with id {} not found", id);
 			return HttpStatus.NOT_FOUND;
 		}
+		audioFileRepository.deleteById(id);
+		return HttpStatus.OK;
 	}
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/service/files/BinaryFileService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/files/BinaryFileService.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.service.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.BinaryFileResponse;
 import fi.poltsi.vempain.file.entity.BinaryFileEntity;
@@ -7,6 +8,7 @@ import fi.poltsi.vempain.file.repository.files.BinaryFileRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,13 +21,26 @@ public class BinaryFileService {
 	private final BinaryFileRepository repository;
 
 	@Transactional(readOnly = true)
-	public PagedResponse<BinaryFileResponse> findAll(int page, int size) {
-		var p       = repository.findAll(PageRequest.of(Math.max(0, page), Math.max(1, size)));
-		var content = p.getContent()
-					   .stream()
-					   .map(BinaryFileEntity::toResponse)
-					   .toList();
-		return PagedResponse.of(content, p.getNumber(), p.getSize(), p.getTotalElements(), p.getTotalPages(), p.isFirst(), p.isLast());
+	public PagedResponse<BinaryFileResponse> findAll(PagedRequest pagedRequest) {
+		var                             safePage   = Math.max(0, pagedRequest.getPage());
+		var                             safeSize   = Math.min(Math.max(pagedRequest.getSize(), 1), 200);
+		var                             sort       = FileSearchHelper.buildSort(pagedRequest.getSortBy(), pagedRequest.getDirection());
+		Specification<BinaryFileEntity> spec       = FileSearchHelper.buildSpecification(pagedRequest.getSearch(), Boolean.TRUE.equals(pagedRequest.getCaseSensitive()));
+		var                             pageable   = PageRequest.of(safePage, safeSize, sort);
+		var                             pageResult = repository.findAll(spec, pageable);
+		var content = pageResult.getContent()
+		                        .stream()
+		                        .map(BinaryFileEntity::toResponse)
+		                        .toList();
+		return PagedResponse.of(
+				content,
+				pageResult.getNumber(),
+				pageResult.getSize(),
+				pageResult.getTotalElements(),
+				pageResult.getTotalPages(),
+				pageResult.isFirst(),
+				pageResult.isLast()
+		);
 	}
 
 	@Transactional(readOnly = true)
@@ -36,13 +51,12 @@ public class BinaryFileService {
 	}
 
 	public HttpStatus delete(long id) {
-		try {
-			repository.deleteById(id);
-			return HttpStatus.OK;
-		} catch (Exception e) {
-			log.warn("Failed to delete binary file {}: {}", id, e.getMessage());
+		if (!repository.existsById(id)) {
+			log.warn("Binary file with id {} not found", id);
 			return HttpStatus.NOT_FOUND;
 		}
+		repository.deleteById(id);
+		return HttpStatus.OK;
 	}
 }
 

--- a/service/src/main/java/fi/poltsi/vempain/file/service/files/DataFileService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/files/DataFileService.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.service.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.DataFileResponse;
 import fi.poltsi.vempain.file.entity.DataFileEntity;
@@ -7,6 +8,7 @@ import fi.poltsi.vempain.file.repository.files.DataFileRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,13 +21,26 @@ public class DataFileService {
 	private final DataFileRepository repository;
 
 	@Transactional(readOnly = true)
-	public PagedResponse<DataFileResponse> findAll(int page, int size) {
-		var p = repository.findAll(PageRequest.of(Math.max(0, page), Math.max(1, size)));
-		var c = p.getContent()
-				 .stream()
-				 .map(DataFileEntity::toResponse)
-				 .toList();
-		return PagedResponse.of(c, p.getNumber(), p.getSize(), p.getTotalElements(), p.getTotalPages(), p.isFirst(), p.isLast());
+	public PagedResponse<DataFileResponse> findAll(PagedRequest pagedRequest) {
+		var                           safePage   = Math.max(0, pagedRequest.getPage());
+		var                           safeSize   = Math.min(Math.max(pagedRequest.getSize(), 1), 200);
+		var                           sort       = FileSearchHelper.buildSort(pagedRequest.getSortBy(), pagedRequest.getDirection());
+		Specification<DataFileEntity> spec       = FileSearchHelper.buildSpecification(pagedRequest.getSearch(), Boolean.TRUE.equals(pagedRequest.getCaseSensitive()));
+		var                           pageable   = PageRequest.of(safePage, safeSize, sort);
+		var                           pageResult = repository.findAll(spec, pageable);
+		var content = pageResult.getContent()
+		                        .stream()
+		                        .map(DataFileEntity::toResponse)
+		                        .toList();
+		return PagedResponse.of(
+				content,
+				pageResult.getNumber(),
+				pageResult.getSize(),
+				pageResult.getTotalElements(),
+				pageResult.getTotalPages(),
+				pageResult.isFirst(),
+				pageResult.isLast()
+		);
 	}
 
 	@Transactional(readOnly = true)
@@ -36,13 +51,12 @@ public class DataFileService {
 	}
 
 	public HttpStatus delete(long id) {
-		try {
-			repository.deleteById(id);
-			return HttpStatus.OK;
-		} catch (Exception e) {
-			log.warn("Failed to delete data file {}: {}", id, e.getMessage());
+		if (!repository.existsById(id)) {
+			log.warn("Data file with id {} not found", id);
 			return HttpStatus.NOT_FOUND;
 		}
+		repository.deleteById(id);
+		return HttpStatus.OK;
 	}
 }
 

--- a/service/src/main/java/fi/poltsi/vempain/file/service/files/DocumentFileService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/files/DocumentFileService.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.service.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.DocumentFileResponse;
 import fi.poltsi.vempain.file.entity.DocumentFileEntity;
@@ -7,6 +8,7 @@ import fi.poltsi.vempain.file.repository.DocumentFileRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,14 +21,18 @@ public class DocumentFileService {
 	private final DocumentFileRepository documentFileRepository;
 
 	@Transactional(readOnly = true)
-	public PagedResponse<DocumentFileResponse> findAll(int page, int size) {
-		var pageable   = PageRequest.of(Math.max(0, page), Math.max(1, size));
-		var pageResult = documentFileRepository.findAll(pageable);
+	public PagedResponse<DocumentFileResponse> findAll(PagedRequest pagedRequest) {
+		var                               safePage   = Math.max(0, pagedRequest.getPage());
+		var                               safeSize   = Math.min(Math.max(pagedRequest.getSize(), 1), 200);
+		var                               sort       = FileSearchHelper.buildSort(pagedRequest.getSortBy(), pagedRequest.getDirection());
+		Specification<DocumentFileEntity> spec       = FileSearchHelper.buildSpecification(pagedRequest.getSearch(), Boolean.TRUE.equals(pagedRequest.getCaseSensitive()));
+		var                               pageable   = PageRequest.of(safePage, safeSize, sort);
+		var                               pageResult = documentFileRepository.findAll(spec, pageable);
 		var content = pageResult.getContent()
 								.stream()
 								.map(DocumentFileEntity::toResponse)
 								.toList();
-		var response = PagedResponse.of(
+		return PagedResponse.of(
 				content,
 				pageResult.getNumber(),
 				pageResult.getSize(),
@@ -35,8 +41,6 @@ public class DocumentFileService {
 				pageResult.isFirst(),
 				pageResult.isLast()
 		);
-		return response;
-
 	}
 
 	@Transactional(readOnly = true)
@@ -47,12 +51,11 @@ public class DocumentFileService {
 	}
 
 	public HttpStatus delete(long id) {
-		try {
-			documentFileRepository.deleteById(id);
-			return HttpStatus.OK;
-		} catch (Exception e) {
-			log.warn("Failed to delete archive file with id {}: {}", id, e.getMessage());
+		if (!documentFileRepository.existsById(id)) {
+			log.warn("Document file with id {} not found", id);
 			return HttpStatus.NOT_FOUND;
 		}
+		documentFileRepository.deleteById(id);
+		return HttpStatus.OK;
 	}
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/service/files/ExecutableFileService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/files/ExecutableFileService.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.service.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.ExecutableFileResponse;
 import fi.poltsi.vempain.file.entity.ExecutableFileEntity;
@@ -7,7 +8,7 @@ import fi.poltsi.vempain.file.repository.files.ExecutableFileRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,15 +21,26 @@ public class ExecutableFileService {
 	private final ExecutableFileRepository repository;
 
 	@Transactional(readOnly = true)
-	public PagedResponse<ExecutableFileResponse> findAll(int page, int size) {
-		var pageable = PageRequest.of(Math.max(0, page), Math.max(1, size), Sort.by("filename")
-																				.ascending());
-		var p        = repository.findAll(pageable);
-		var content  = p.getContent()
-						.stream()
-						.map(ExecutableFileEntity::toResponse)
-						.toList();
-		return PagedResponse.of(content, p.getNumber(), p.getSize(), p.getTotalElements(), p.getTotalPages(), p.isFirst(), p.isLast());
+	public PagedResponse<ExecutableFileResponse> findAll(PagedRequest pagedRequest) {
+		var                                 safePage   = Math.max(0, pagedRequest.getPage());
+		var                                 safeSize   = Math.min(Math.max(pagedRequest.getSize(), 1), 200);
+		var                                 sort       = FileSearchHelper.buildSort(pagedRequest.getSortBy(), pagedRequest.getDirection());
+		Specification<ExecutableFileEntity> spec       = FileSearchHelper.buildSpecification(pagedRequest.getSearch(), Boolean.TRUE.equals(pagedRequest.getCaseSensitive()));
+		var                                 pageable   = PageRequest.of(safePage, safeSize, sort);
+		var                                 pageResult = repository.findAll(spec, pageable);
+		var content = pageResult.getContent()
+		                        .stream()
+		                        .map(ExecutableFileEntity::toResponse)
+		                        .toList();
+		return PagedResponse.of(
+				content,
+				pageResult.getNumber(),
+				pageResult.getSize(),
+				pageResult.getTotalElements(),
+				pageResult.getTotalPages(),
+				pageResult.isFirst(),
+				pageResult.isLast()
+		);
 	}
 
 	@Transactional(readOnly = true)
@@ -39,13 +51,12 @@ public class ExecutableFileService {
 	}
 
 	public HttpStatus delete(long id) {
-		try {
-			repository.deleteById(id);
-			return HttpStatus.OK;
-		} catch (Exception e) {
-			log.warn("Failed to delete executable file {}: {}", id, e.getMessage());
+		if (!repository.existsById(id)) {
+			log.warn("Executable file with id {} not found", id);
 			return HttpStatus.NOT_FOUND;
 		}
+		repository.deleteById(id);
+		return HttpStatus.OK;
 	}
 }
 

--- a/service/src/main/java/fi/poltsi/vempain/file/service/files/FileSearchHelper.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/files/FileSearchHelper.java
@@ -1,0 +1,93 @@
+package fi.poltsi.vempain.file.service.files;
+
+import fi.poltsi.vempain.file.entity.FileEntity;
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Shared helper for building JPA Specifications and Sort objects from PagedRequest parameters
+ * across all typed file services (ArchiveFileService, ImageFileService, etc.).
+ */
+public final class FileSearchHelper {
+
+	private static final Pattern TOKEN_PATTERN = Pattern.compile("\"([^\"]+)\"|(\\S+)");
+
+	private FileSearchHelper() {
+	}
+
+	/**
+	 * Builds a JPA Specification that performs a multi-token LIKE search across
+	 * filename, filePath, description, and mimetype fields inherited from FileEntity.
+	 * Each token must match at least one of those fields (AND between tokens, OR between fields).
+	 *
+	 * @param search        raw search string (may be null or blank)
+	 * @param caseSensitive whether the search should be case-sensitive
+	 * @return Specification, or null if search is empty
+	 */
+	public static <T extends FileEntity> Specification<T> buildSpecification(String search, boolean caseSensitive) {
+		List<String> tokens = tokenize(search);
+		if (tokens.isEmpty()) {
+			return null;
+		}
+
+		return (root, query, cb) -> {
+			List<Predicate> andPredicates = new ArrayList<>();
+			for (String token : tokens) {
+				String          pattern      = "%" + (caseSensitive ? token : token.toLowerCase()) + "%";
+				List<Predicate> orPredicates = new ArrayList<>();
+				for (String field : List.of("filename", "filePath", "description", "mimetype")) {
+					var path = root.<String>get(field);
+					if (caseSensitive) {
+						orPredicates.add(cb.like(path, pattern));
+					} else {
+						orPredicates.add(cb.like(cb.lower(path), pattern));
+					}
+				}
+				andPredicates.add(cb.or(orPredicates.toArray(new Predicate[0])));
+			}
+			return cb.and(andPredicates.toArray(new Predicate[0]));
+		};
+	}
+
+	/**
+	 * Builds a Sort from sortBy / direction parameters.
+	 * Supported sort fields: id, filename, filepath/file_path, description, mimetype, filesize, created, modified.
+	 * Defaults to filename ASC.
+	 */
+	public static Sort buildSort(String sortBy, Sort.Direction direction) {
+		String property = switch (sortBy == null ? "" : sortBy.toLowerCase()) {
+			case "id" -> "id";
+			case "filename" -> "filename";
+			case "filepath", "file_path" -> "filePath";
+			case "description" -> "description";
+			case "mimetype" -> "mimetype";
+			case "filesize" -> "filesize";
+			case "created" -> "created";
+			case "modified" -> "modified";
+			default -> "filename";
+		};
+		Sort.Direction dir = direction == null ? Sort.Direction.ASC : direction;
+		return Sort.by(dir, property);
+	}
+
+	private static List<String> tokenize(String search) {
+		if (search == null || search.isBlank()) {
+			return List.of();
+		}
+		Matcher      matcher = TOKEN_PATTERN.matcher(search);
+		List<String> tokens  = new ArrayList<>();
+		while (matcher.find()) {
+			String quoted = matcher.group(1);
+			String word   = matcher.group(2);
+			tokens.add(quoted != null ? quoted : word);
+		}
+		return tokens;
+	}
+}
+

--- a/service/src/main/java/fi/poltsi/vempain/file/service/files/FontFileService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/files/FontFileService.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.service.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.FontFileResponse;
 import fi.poltsi.vempain.file.entity.FontFileEntity;
@@ -7,6 +8,7 @@ import fi.poltsi.vempain.file.repository.files.FontFileRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,9 +21,13 @@ public class FontFileService {
 	private final FontFileRepository fontFileRepository;
 
 	@Transactional(readOnly = true)
-	public PagedResponse<FontFileResponse> findAll(int page, int size) {
-		var pageable   = PageRequest.of(Math.max(0, page), Math.max(1, size));
-		var pageResult = fontFileRepository.findAll(pageable);
+	public PagedResponse<FontFileResponse> findAll(PagedRequest pagedRequest) {
+		var                           safePage   = Math.max(0, pagedRequest.getPage());
+		var                           safeSize   = Math.min(Math.max(pagedRequest.getSize(), 1), 200);
+		var                           sort       = FileSearchHelper.buildSort(pagedRequest.getSortBy(), pagedRequest.getDirection());
+		Specification<FontFileEntity> spec       = FileSearchHelper.buildSpecification(pagedRequest.getSearch(), Boolean.TRUE.equals(pagedRequest.getCaseSensitive()));
+		var                           pageable   = PageRequest.of(safePage, safeSize, sort);
+		var                           pageResult = fontFileRepository.findAll(spec, pageable);
 		var content = pageResult.getContent()
 								.stream()
 								.map(FontFileEntity::toResponse)
@@ -35,7 +41,6 @@ public class FontFileService {
 				pageResult.isFirst(),
 				pageResult.isLast()
 		);
-
 	}
 
 	@Transactional(readOnly = true)
@@ -46,12 +51,11 @@ public class FontFileService {
 	}
 
 	public HttpStatus delete(long id) {
-		try {
-			fontFileRepository.deleteById(id);
-			return HttpStatus.OK;
-		} catch (Exception e) {
-			log.warn("Failed to delete archive file with id {}: {}", id, e.getMessage());
+		if (!fontFileRepository.existsById(id)) {
+			log.warn("Font file with id {} not found", id);
 			return HttpStatus.NOT_FOUND;
 		}
+		fontFileRepository.deleteById(id);
+		return HttpStatus.OK;
 	}
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/service/files/IconFileService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/files/IconFileService.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.service.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.IconFileResponse;
 import fi.poltsi.vempain.file.entity.IconFileEntity;
@@ -7,6 +8,7 @@ import fi.poltsi.vempain.file.repository.files.IconFileRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,9 +21,13 @@ public class IconFileService {
 	private final IconFileRepository iconFileRepository;
 
 	@Transactional(readOnly = true)
-	public PagedResponse<IconFileResponse> findAll(int page, int size) {
-		var pageable   = PageRequest.of(Math.max(0, page), Math.max(1, size));
-		var pageResult = iconFileRepository.findAll(pageable);
+	public PagedResponse<IconFileResponse> findAll(PagedRequest pagedRequest) {
+		var                           safePage   = Math.max(0, pagedRequest.getPage());
+		var                           safeSize   = Math.min(Math.max(pagedRequest.getSize(), 1), 200);
+		var                           sort       = FileSearchHelper.buildSort(pagedRequest.getSortBy(), pagedRequest.getDirection());
+		Specification<IconFileEntity> spec       = FileSearchHelper.buildSpecification(pagedRequest.getSearch(), Boolean.TRUE.equals(pagedRequest.getCaseSensitive()));
+		var                           pageable   = PageRequest.of(safePage, safeSize, sort);
+		var                           pageResult = iconFileRepository.findAll(spec, pageable);
 		var content = pageResult.getContent()
 								.stream()
 								.map(IconFileEntity::toResponse)
@@ -35,7 +41,6 @@ public class IconFileService {
 				pageResult.isFirst(),
 				pageResult.isLast()
 		);
-
 	}
 
 	@Transactional(readOnly = true)
@@ -46,12 +51,11 @@ public class IconFileService {
 	}
 
 	public HttpStatus delete(long id) {
-		try {
-			iconFileRepository.deleteById(id);
-			return HttpStatus.OK;
-		} catch (Exception e) {
-			log.warn("Failed to delete archive file with id {}: {}", id, e.getMessage());
+		if (!iconFileRepository.existsById(id)) {
+			log.warn("Icon file with id {} not found", id);
 			return HttpStatus.NOT_FOUND;
 		}
+		iconFileRepository.deleteById(id);
+		return HttpStatus.OK;
 	}
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/service/files/ImageFileService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/files/ImageFileService.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.service.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.ImageFileResponse;
 import fi.poltsi.vempain.file.entity.ImageFileEntity;
@@ -7,7 +8,7 @@ import fi.poltsi.vempain.file.repository.files.ImageFileRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,24 +21,17 @@ public class ImageFileService {
 	private final ImageFileRepository imageFileRepository;
 
 	@Transactional(readOnly = true)
-	public PagedResponse<ImageFileResponse> findAll(int page, int size) {
-		// Default: sort by file_path ascending
-		return findAll(page, size, "filePath", Sort.Direction.ASC);
-	}
-
-	@Transactional(readOnly = true)
-	public PagedResponse<ImageFileResponse> findAll(int page, int size, String sortBy, Sort.Direction direction) {
-		var safePage = Math.max(0, page);
-		var safeSize = Math.max(1, size);
-		var sort     = Sort.by(direction == null ? Sort.Direction.ASC : direction, sortBy == null ? "filePath" : sortBy);
+	public PagedResponse<ImageFileResponse> findAll(PagedRequest pagedRequest) {
+		var                            safePage   = Math.max(0, pagedRequest.getPage());
+		var                            safeSize   = Math.min(Math.max(pagedRequest.getSize(), 1), 200);
+		var                            sort       = FileSearchHelper.buildSort(pagedRequest.getSortBy(), pagedRequest.getDirection());
+		Specification<ImageFileEntity> spec       = FileSearchHelper.buildSpecification(pagedRequest.getSearch(), Boolean.TRUE.equals(pagedRequest.getCaseSensitive()));
 		var pageable = PageRequest.of(safePage, safeSize, sort);
-
-		var pageResult = imageFileRepository.findAll(pageable);
+		var                            pageResult = imageFileRepository.findAll(spec, pageable);
 		var content = pageResult.getContent()
 								.stream()
 								.map(ImageFileEntity::toResponse)
 								.toList();
-
 		return PagedResponse.of(
 				content,
 				pageResult.getNumber(),
@@ -49,6 +43,7 @@ public class ImageFileService {
 		);
 	}
 
+
 	@Transactional(readOnly = true)
 	public ImageFileResponse findById(long id) {
 		var entityOpt = imageFileRepository.findById(id);
@@ -57,12 +52,11 @@ public class ImageFileService {
 	}
 
 	public HttpStatus delete(long id) {
-		try {
-			imageFileRepository.deleteById(id);
-			return HttpStatus.OK;
-		} catch (Exception e) {
-			log.warn("Failed to delete archive file with id {}: {}", id, e.getMessage());
+		if (!imageFileRepository.existsById(id)) {
+			log.warn("Image file with id {} not found", id);
 			return HttpStatus.NOT_FOUND;
 		}
+		imageFileRepository.deleteById(id);
+		return HttpStatus.OK;
 	}
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/service/files/InteractiveFileService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/files/InteractiveFileService.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.service.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.InteractiveFileResponse;
 import fi.poltsi.vempain.file.entity.InteractiveFileEntity;
@@ -7,7 +8,7 @@ import fi.poltsi.vempain.file.repository.files.InteractiveFileRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,15 +21,26 @@ public class InteractiveFileService {
 	private final InteractiveFileRepository repository;
 
 	@Transactional(readOnly = true)
-	public PagedResponse<InteractiveFileResponse> findAll(int page, int size) {
-		var pageable = PageRequest.of(Math.max(0, page), Math.max(1, size), Sort.by("filename")
-																				.ascending());
-		var p        = repository.findAll(pageable);
-		var content  = p.getContent()
-						.stream()
-						.map(InteractiveFileEntity::toResponse)
-						.toList();
-		return PagedResponse.of(content, p.getNumber(), p.getSize(), p.getTotalElements(), p.getTotalPages(), p.isFirst(), p.isLast());
+	public PagedResponse<InteractiveFileResponse> findAll(PagedRequest pagedRequest) {
+		var                                  safePage   = Math.max(0, pagedRequest.getPage());
+		var                                  safeSize   = Math.min(Math.max(pagedRequest.getSize(), 1), 200);
+		var                                  sort       = FileSearchHelper.buildSort(pagedRequest.getSortBy(), pagedRequest.getDirection());
+		Specification<InteractiveFileEntity> spec       = FileSearchHelper.buildSpecification(pagedRequest.getSearch(), Boolean.TRUE.equals(pagedRequest.getCaseSensitive()));
+		var                                  pageable   = PageRequest.of(safePage, safeSize, sort);
+		var                                  pageResult = repository.findAll(spec, pageable);
+		var content = pageResult.getContent()
+		                        .stream()
+		                        .map(InteractiveFileEntity::toResponse)
+		                        .toList();
+		return PagedResponse.of(
+				content,
+				pageResult.getNumber(),
+				pageResult.getSize(),
+				pageResult.getTotalElements(),
+				pageResult.getTotalPages(),
+				pageResult.isFirst(),
+				pageResult.isLast()
+		);
 	}
 
 	@Transactional(readOnly = true)
@@ -39,13 +51,12 @@ public class InteractiveFileService {
 	}
 
 	public HttpStatus delete(long id) {
-		try {
-			repository.deleteById(id);
-			return HttpStatus.OK;
-		} catch (Exception e) {
-			log.warn("Failed to delete interactive file {}: {}", id, e.getMessage());
+		if (!repository.existsById(id)) {
+			log.warn("Interactive file with id {} not found", id);
 			return HttpStatus.NOT_FOUND;
 		}
+		repository.deleteById(id);
+		return HttpStatus.OK;
 	}
 }
 

--- a/service/src/main/java/fi/poltsi/vempain/file/service/files/ThumbFileService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/files/ThumbFileService.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.service.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.ThumbFileResponse;
 import fi.poltsi.vempain.file.entity.ThumbFileEntity;
@@ -7,7 +8,7 @@ import fi.poltsi.vempain.file.repository.files.ThumbFileRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,15 +21,26 @@ public class ThumbFileService {
 	private final ThumbFileRepository repository;
 
 	@Transactional(readOnly = true)
-	public PagedResponse<ThumbFileResponse> findAll(int page, int size) {
-		var pageable = PageRequest.of(Math.max(0, page), Math.max(1, size), Sort.by("filename")
-																				.ascending());
-		var p        = repository.findAll(pageable);
-		var content  = p.getContent()
-						.stream()
-						.map(ThumbFileEntity::toResponse)
-						.toList();
-		return PagedResponse.of(content, p.getNumber(), p.getSize(), p.getTotalElements(), p.getTotalPages(), p.isFirst(), p.isLast());
+	public PagedResponse<ThumbFileResponse> findAll(PagedRequest pagedRequest) {
+		var                            safePage   = Math.max(0, pagedRequest.getPage());
+		var                            safeSize   = Math.min(Math.max(pagedRequest.getSize(), 1), 200);
+		var                            sort       = FileSearchHelper.buildSort(pagedRequest.getSortBy(), pagedRequest.getDirection());
+		Specification<ThumbFileEntity> spec       = FileSearchHelper.buildSpecification(pagedRequest.getSearch(), Boolean.TRUE.equals(pagedRequest.getCaseSensitive()));
+		var                            pageable   = PageRequest.of(safePage, safeSize, sort);
+		var                            pageResult = repository.findAll(spec, pageable);
+		var content = pageResult.getContent()
+		                        .stream()
+		                        .map(ThumbFileEntity::toResponse)
+		                        .toList();
+		return PagedResponse.of(
+				content,
+				pageResult.getNumber(),
+				pageResult.getSize(),
+				pageResult.getTotalElements(),
+				pageResult.getTotalPages(),
+				pageResult.isFirst(),
+				pageResult.isLast()
+		);
 	}
 
 	@Transactional(readOnly = true)
@@ -39,13 +51,12 @@ public class ThumbFileService {
 	}
 
 	public HttpStatus delete(long id) {
-		try {
-			repository.deleteById(id);
-			return HttpStatus.OK;
-		} catch (Exception e) {
-			log.warn("Failed to delete thumb file {}: {}", id, e.getMessage());
+		if (!repository.existsById(id)) {
+			log.warn("Thumb file with id {} not found", id);
 			return HttpStatus.NOT_FOUND;
 		}
+		repository.deleteById(id);
+		return HttpStatus.OK;
 	}
 }
 

--- a/service/src/main/java/fi/poltsi/vempain/file/service/files/VectorFileService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/files/VectorFileService.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.service.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.VectorFileResponse;
 import fi.poltsi.vempain.file.entity.VectorFileEntity;
@@ -7,6 +8,7 @@ import fi.poltsi.vempain.file.repository.files.VectorFileRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,9 +21,13 @@ public class VectorFileService {
 	private final VectorFileRepository vectorFileRepository;
 
 	@Transactional(readOnly = true)
-	public PagedResponse<VectorFileResponse> findAll(int page, int size) {
-		var pageable   = PageRequest.of(Math.max(0, page), Math.max(1, size));
-		var pageResult = vectorFileRepository.findAll(pageable);
+	public PagedResponse<VectorFileResponse> findAll(PagedRequest pagedRequest) {
+		var                             safePage   = Math.max(0, pagedRequest.getPage());
+		var                             safeSize   = Math.min(Math.max(pagedRequest.getSize(), 1), 200);
+		var                             sort       = FileSearchHelper.buildSort(pagedRequest.getSortBy(), pagedRequest.getDirection());
+		Specification<VectorFileEntity> spec       = FileSearchHelper.buildSpecification(pagedRequest.getSearch(), Boolean.TRUE.equals(pagedRequest.getCaseSensitive()));
+		var                             pageable   = PageRequest.of(safePage, safeSize, sort);
+		var                             pageResult = vectorFileRepository.findAll(spec, pageable);
 		var content = pageResult.getContent()
 								.stream()
 								.map(VectorFileEntity::toResponse)
@@ -35,7 +41,6 @@ public class VectorFileService {
 				pageResult.isFirst(),
 				pageResult.isLast()
 		);
-
 	}
 
 	@Transactional(readOnly = true)
@@ -46,12 +51,11 @@ public class VectorFileService {
 	}
 
 	public HttpStatus delete(long id) {
-		try {
-			vectorFileRepository.deleteById(id);
-			return HttpStatus.OK;
-		} catch (Exception e) {
-			log.warn("Failed to delete archive file with id {}: {}", id, e.getMessage());
+		if (!vectorFileRepository.existsById(id)) {
+			log.warn("Vector file with id {} not found", id);
 			return HttpStatus.NOT_FOUND;
 		}
+		vectorFileRepository.deleteById(id);
+		return HttpStatus.OK;
 	}
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/service/files/VideoFileService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/files/VideoFileService.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.service.files;
 
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.file.api.response.files.VideoFileResponse;
 import fi.poltsi.vempain.file.entity.VideoFileEntity;
@@ -7,6 +8,7 @@ import fi.poltsi.vempain.file.repository.files.VideoFileRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,9 +21,13 @@ public class VideoFileService {
 	private final VideoFileRepository videoFileRepository;
 
 	@Transactional(readOnly = true)
-	public PagedResponse<VideoFileResponse> findAll(int page, int size) {
-		var pageable   = PageRequest.of(Math.max(0, page), Math.max(1, size));
-		var pageResult = videoFileRepository.findAll(pageable);
+	public PagedResponse<VideoFileResponse> findAll(PagedRequest pagedRequest) {
+		var                            safePage   = Math.max(0, pagedRequest.getPage());
+		var                            safeSize   = Math.min(Math.max(pagedRequest.getSize(), 1), 200);
+		var                            sort       = FileSearchHelper.buildSort(pagedRequest.getSortBy(), pagedRequest.getDirection());
+		Specification<VideoFileEntity> spec       = FileSearchHelper.buildSpecification(pagedRequest.getSearch(), Boolean.TRUE.equals(pagedRequest.getCaseSensitive()));
+		var                            pageable   = PageRequest.of(safePage, safeSize, sort);
+		var                            pageResult = videoFileRepository.findAll(spec, pageable);
 		var content = pageResult.getContent()
 								.stream()
 								.map(VideoFileEntity::toResponse)
@@ -35,7 +41,6 @@ public class VideoFileService {
 				pageResult.isFirst(),
 				pageResult.isLast()
 		);
-
 	}
 
 	@Transactional(readOnly = true)
@@ -47,12 +52,11 @@ public class VideoFileService {
 	}
 
 	public HttpStatus delete(long id) {
-		try {
-			videoFileRepository.deleteById(id);
-			return HttpStatus.OK;
-		} catch (Exception e) {
-			log.warn("Failed to delete archive file with id {}: {}", id, e.getMessage());
+		if (!videoFileRepository.existsById(id)) {
+			log.warn("Video file with id {} not found", id);
 			return HttpStatus.NOT_FOUND;
 		}
+		videoFileRepository.deleteById(id);
+		return HttpStatus.OK;
 	}
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/tools/MetadataTool.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/tools/MetadataTool.java
@@ -1049,7 +1049,7 @@ public class MetadataTool {
 				&& !root.isEmpty()) {
 				var first     = root.get(0);
 				var valueNode = first.get(tag);
-				return valueNode != null ? valueNode.asText() : "";
+				return valueNode != null ? mapper.convertValue(valueNode, String.class) : "";
 			}
 		} catch (Exception e) {
 			log.error("Failed to parse exiftool JSON output", e);

--- a/service/src/test/java/fi/poltsi/vempain/file/controller/AbstractControllerCTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/controller/AbstractControllerCTC.java
@@ -1,0 +1,115 @@
+package fi.poltsi.vempain.file.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+
+/**
+ * Abstract base class for Controller Test Classes (CTC).
+ *
+ * <p>All concrete CTCs should extend this class. Provides:
+ * <ul>
+ *   <li>Spring Boot full-context test setup with MockMvc</li>
+ *   <li>Testcontainers PostgreSQL via {@code jdbc:tc:} URL in test/resources/application.yaml</li>
+ *   <li>Authenticated helper methods for GET / POST / PUT / DELETE</li>
+ *   <li>A {@link JdbcTemplate} for data seeding and cleanup</li>
+ * </ul>
+ */
+@SpringBootTest(properties = {
+		"vempain.app.frontend-url=http://localhost:3000",
+		"vempain.original-root-directory=/tmp",
+		"vempain.export-root-directory=/tmp"
+})
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public abstract class AbstractControllerCTC {
+
+	@Autowired
+	protected MockMvc mockMvc;
+
+	@Autowired
+	protected JdbcTemplate jdbcTemplate;
+
+	// -----------------------------------------------------------------------
+	// Helper methods — authenticated requests
+	// -----------------------------------------------------------------------
+
+	protected ResultActions doGet(String path) throws Exception {
+		return mockMvc.perform(
+				get(path).with(user("ctc-user").roles("USER")));
+	}
+
+	protected ResultActions doPost(String path, String body) throws Exception {
+		return mockMvc.perform(
+				post(path)
+						.with(user("ctc-user").roles("USER"))
+						.with(csrf())
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(body));
+	}
+
+	protected ResultActions doPut(String path, String body) throws Exception {
+		return mockMvc.perform(
+				put(path)
+						.with(user("ctc-user").roles("USER"))
+						.with(csrf())
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(body));
+	}
+
+	protected ResultActions doDelete(String path) throws Exception {
+		return mockMvc.perform(
+				delete(path)
+						.with(user("ctc-user").roles("USER"))
+						.with(csrf()));
+	}
+
+	// -----------------------------------------------------------------------
+	// Seed helpers
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Inserts a row into {@code files} (parent table, JOINED inheritance) using
+	 * {@code OVERRIDING SYSTEM VALUE} so that an explicit ID can be provided.
+	 *
+	 * @param id       explicit file id (use values ≥ 9001 to avoid Flyway-seed conflicts)
+	 * @param fileType file_type column value, e.g. "ARCHIVE"
+	 * @param mimeType MIME type string
+	 * @param filename file name
+	 * @param filePath directory path
+	 */
+	protected void seedFileRow(long id, String fileType, String mimeType, String filename, String filePath) {
+		jdbcTemplate.update(
+				"""
+						INSERT INTO files
+						    (id, acl_id, external_file_id, filename, file_path, mimetype,
+						     filesize, sha256sum, file_type, creator, created, locked, metadata_raw)
+						OVERRIDING SYSTEM VALUE
+						VALUES (?, ?, ?, ?, ?, ?, 1024,
+						        'a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0',
+						        ?, 1, NOW(), false, '{}')
+						""",
+				id, id, "test-ext-" + fileType.toLowerCase(),
+				filename, filePath, mimeType, fileType);
+	}
+
+	/**
+	 * Deletes a file row (and cascades to the type-specific child table).
+	 */
+	protected void deleteFileRow(long id) {
+		jdbcTemplate.update("DELETE FROM files WHERE id = ?", id);
+	}
+}
+

--- a/service/src/test/java/fi/poltsi/vempain/file/controller/FileGroupControllerCTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/controller/FileGroupControllerCTC.java
@@ -1,0 +1,169 @@
+package fi.poltsi.vempain.file.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Controller Test Class (CTC) for {@link FileGroupController}.
+ *
+ * <p>Tests all REST endpoints declared in {@code FileGroupAPI}:
+ * <ul>
+ *   <li>POST /api/file-groups/paged  – paged list</li>
+ *   <li>GET  /api/file-groups/{id}   – single group by id</li>
+ *   <li>POST /api/file-groups        – create</li>
+ *   <li>PUT  /api/file-groups        – update</li>
+ * </ul>
+ */
+class FileGroupControllerCTC extends AbstractControllerCTC {
+
+	@BeforeEach
+	void cleanFileGroups() {
+		// CASCADE removes file_group_files rows automatically
+		jdbcTemplate.execute("TRUNCATE TABLE file_group RESTART IDENTITY CASCADE");
+	}
+
+	// -----------------------------------------------------------------------
+	// POST /api/file-groups/paged
+	// -----------------------------------------------------------------------
+
+	@Test
+	void getFileGroups_returnsOkWithEmptyPage_whenNoGroupsExist() throws Exception {
+		doPost("/file-groups/paged", "{\"page\":0,\"size\":10}")
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.content").isArray())
+				.andExpect(jsonPath("$.content", hasSize(0)));
+	}
+
+	@Test
+	void getFileGroups_returnsOkWithData_whenGroupsExist() throws Exception {
+		jdbcTemplate.update(
+				"INSERT INTO file_group (path, group_name, description) VALUES (?, ?, ?)",
+				"/photos/2025", "Holiday Photos", "Best photos from 2025");
+		jdbcTemplate.update(
+				"INSERT INTO file_group (path, group_name, description) VALUES (?, ?, ?)",
+				"/videos/2025", "Holiday Videos", "Best videos from 2025");
+
+		doPost("/file-groups/paged", "{\"page\":0,\"size\":10}")
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.content").isArray())
+				.andExpect(jsonPath("$.content", hasSize(greaterThanOrEqualTo(2))));
+	}
+
+	@Test
+	void getFileGroups_supportsSortAndSearch() throws Exception {
+		jdbcTemplate.update(
+				"INSERT INTO file_group (path, group_name, description) VALUES (?, ?, ?)",
+				"/alpha", "Alpha Group", "First group");
+		jdbcTemplate.update(
+				"INSERT INTO file_group (path, group_name, description) VALUES (?, ?, ?)",
+				"/beta", "Beta Group", "Second group");
+
+		doPost("/file-groups/paged",
+		       "{\"page\":0,\"size\":10,\"sort_by\":\"group_name\",\"direction\":\"ASC\",\"search\":\"Alpha\"}")
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.content", hasSize(1)))
+				.andExpect(jsonPath("$.content[0].group_name", is("Alpha Group")));
+	}
+
+	// -----------------------------------------------------------------------
+	// GET /api/file-groups/{id}
+	// -----------------------------------------------------------------------
+
+	@Test
+	void getFileGroupById_returns404_whenNotFound() throws Exception {
+		doGet("/file-groups/99999")
+				.andExpect(status().isNotFound());
+	}
+
+	@Test
+	void getFileGroupById_returns200_whenExists() throws Exception {
+		jdbcTemplate.update(
+				"INSERT INTO file_group (path, group_name, description) VALUES (?, ?, ?)",
+				"/test/path", "Test Group", "A test group");
+		Long id = jdbcTemplate.queryForObject("SELECT MAX(id) FROM file_group", Long.class);
+
+		doGet("/file-groups/" + id)
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.id", is(id.intValue())))
+				.andExpect(jsonPath("$.group_name", is("Test Group")))
+				.andExpect(jsonPath("$.path", is("/test/path")));
+	}
+
+	// -----------------------------------------------------------------------
+	// POST /api/file-groups  (create)
+	// -----------------------------------------------------------------------
+
+	@Test
+	void addFileGroup_returns201_whenRequestIsValid() throws Exception {
+		doPost("/file-groups",
+		       "{\"path\":\"/new/path\",\"group_name\":\"New Group\",\"description\":\"desc\",\"file_ids\":[]}")
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.group_name", is("New Group")))
+				.andExpect(jsonPath("$.path", is("/new/path")));
+	}
+
+	@Test
+	void addFileGroup_returns400_whenGroupNameIsMissing() throws Exception {
+		// group_name is @NotNull — omitting it triggers validation error
+		doPost("/file-groups",
+		       "{\"path\":\"/new/path\",\"file_ids\":[]}")
+				.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	void addFileGroup_returns400_whenFileIdsIsNull() throws Exception {
+		// file_ids is @NotNull
+		doPost("/file-groups",
+		       "{\"path\":\"/new/path\",\"group_name\":\"g\"}")
+				.andExpect(status().isBadRequest());
+	}
+
+	// -----------------------------------------------------------------------
+	// PUT /api/file-groups  (update)
+	// -----------------------------------------------------------------------
+
+	@Test
+	void updateFileGroup_returns200_whenGroupExistsAndRequestIsValid() throws Exception {
+		jdbcTemplate.update(
+				"INSERT INTO file_group (path, group_name, description) VALUES (?, ?, ?)",
+				"/original", "Original Name", "original desc");
+		Long id = jdbcTemplate.queryForObject("SELECT MAX(id) FROM file_group", Long.class);
+
+		String updateBody = """
+				{
+				  "id": %d,
+				  "path": "/updated",
+				  "group_name": "Updated Name",
+				  "description": "updated desc",
+				  "file_ids": []
+				}
+				""".formatted(id);
+
+		doPut("/file-groups", updateBody)
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.group_name", is("Updated Name")))
+				.andExpect(jsonPath("$.path", is("/updated")));
+	}
+
+	@Test
+	void updateFileGroup_returns404_whenGroupDoesNotExist() throws Exception {
+		// Spring MVC 6.2+ maps EntityNotFoundException to 404
+		String body = """
+				{
+				  "id": 99999,
+				  "path": "/updated",
+				  "group_name": "Updated Name",
+				  "file_ids": []
+				}
+				""";
+		doPut("/file-groups", body)
+				.andExpect(status().isNotFound());
+	}
+}
+

--- a/service/src/test/java/fi/poltsi/vempain/file/controller/FileScannerControllerCTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/controller/FileScannerControllerCTC.java
@@ -1,0 +1,65 @@
+package fi.poltsi.vempain.file.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Controller Test Class (CTC) for {@link FileScannerController}.
+ *
+ * <p>Tests the REST endpoint declared in {@code FileScannerAPI}:
+ * <ul>
+ *   <li>POST /api/scan-files – scan a directory for new files</li>
+ * </ul>
+ *
+ * <p>The scan root is configured as {@code /tmp} in test properties.
+ * The scan endpoint returns 200 even when no new files are found; it only
+ * returns 400 when the request fails Bean Validation.
+ */
+class FileScannerControllerCTC extends AbstractControllerCTC {
+
+	private static final String TEST_SCAN_DIR = "/ctc-scan";
+
+	@BeforeEach
+	void ensureTestScanDirectoryExists() throws Exception {
+		Files.createDirectories(Path.of("/tmp", TEST_SCAN_DIR.substring(1)));
+	}
+
+	// -----------------------------------------------------------------------
+	// POST /api/scan-files
+	// -----------------------------------------------------------------------
+
+	@Test
+	void scan_returns200_withValidOriginalDirectory() throws Exception {
+		doPost("/scan-files", "{\"original_directory\":\"%s\"}".formatted(TEST_SCAN_DIR))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.scan_original_response").exists());
+	}
+
+	@Test
+	void scan_returns200_withValidExportDirectory() throws Exception {
+		doPost("/scan-files", "{\"export_directory\":\"%s\"}".formatted(TEST_SCAN_DIR))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.scan_export_response").exists());
+	}
+
+	@Test
+	void scan_returns400_whenBothDirectoriesAreNull() throws Exception {
+		// @AssertTrue on isDirectoryValid() fails when both fields are null → 400
+		doPost("/scan-files", "{}")
+				.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	void scan_returns400_whenDirectoryPathDoesNotMatchPattern() throws Exception {
+		// Pattern requires path to start with '/' and contain only alphanumerics / dashes / underscores
+		doPost("/scan-files", "{\"original_directory\":\"no-leading-slash\"}")
+				.andExpect(status().isBadRequest());
+	}
+}
+

--- a/service/src/test/java/fi/poltsi/vempain/file/controller/LocationControllerCTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/controller/LocationControllerCTC.java
@@ -1,0 +1,227 @@
+package fi.poltsi.vempain.file.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Controller Test Class (CTC) for {@link LocationController}.
+ *
+ * <p>Tests all REST endpoints declared in {@code LocationAPI}:
+ * <ul>
+ *   <li>GET    /api/location/{id}              – get GPS location by id</li>
+ *   <li>GET    /api/location/guard             – list all location guards</li>
+ *   <li>GET    /api/location/guard/{id}        – check if GPS location is guarded</li>
+ *   <li>POST   /api/location/guard             – create location guard</li>
+ *   <li>PUT    /api/location/guard             – update location guard</li>
+ *   <li>DELETE /api/location/guard/{id}        – delete location guard</li>
+ * </ul>
+ *
+ * <p>Note: {@code LocationAPI.GUARD_PATH = "/location/guard"} (singular).
+ */
+class LocationControllerCTC extends AbstractControllerCTC {
+
+	@BeforeEach
+	void cleanLocationData() {
+		jdbcTemplate.execute("TRUNCATE TABLE location_guard RESTART IDENTITY CASCADE");
+		jdbcTemplate.execute("TRUNCATE TABLE gps_locations RESTART IDENTITY CASCADE");
+	}
+
+	// -----------------------------------------------------------------------
+	// GET /api/location/{id}
+	// -----------------------------------------------------------------------
+
+	@Test
+	void getLocationById_returns404_whenLocationDoesNotExist() throws Exception {
+		doGet("/location/99999")
+				.andExpect(status().isNotFound());
+	}
+
+	@Test
+	void getLocationById_returns200_whenLocationExists() throws Exception {
+		jdbcTemplate.update(
+				"INSERT INTO gps_locations (latitude, latitude_ref, longitude, longitude_ref) VALUES (60.17000, 'N', 24.93500, 'E')");
+		Long gpsId = jdbcTemplate.queryForObject("SELECT MAX(id) FROM gps_locations", Long.class);
+
+		doGet("/location/" + gpsId)
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.id", is(gpsId.intValue())))
+				.andExpect(jsonPath("$.latitude", notNullValue()));
+	}
+
+	// -----------------------------------------------------------------------
+	// GET /api/location/guard
+	// -----------------------------------------------------------------------
+
+	@Test
+	void findAllLocationGuards_returnsEmptyList_whenNoGuardsExist() throws Exception {
+		doGet("/location/guard")
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$").isArray())
+				.andExpect(jsonPath("$", hasSize(0)));
+	}
+
+	@Test
+	void findAllLocationGuards_returnsList_whenGuardsExist() throws Exception {
+		jdbcTemplate.update(
+				"INSERT INTO location_guard (guard_type, primary_longitude, primary_latitude, secondary_longitude, secondary_latitude) VALUES ('SQUARE', 24.90000, 60.10000, 24.95000, 60.15000)");
+		jdbcTemplate.update(
+				"INSERT INTO location_guard (guard_type, primary_longitude, primary_latitude, radius) VALUES ('CIRCLE', 24.93500, 60.17000, 200.00000)");
+
+		doGet("/location/guard")
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$").isArray())
+				.andExpect(jsonPath("$", hasSize(2)));
+	}
+
+	// -----------------------------------------------------------------------
+	// GET /api/location/guard/{gpsLocationId}
+	// -----------------------------------------------------------------------
+
+	@Test
+	void isGuardedLocation_returnsFalse_whenLocationDoesNotExist() throws Exception {
+		doGet("/location/guard/99999")
+				.andExpect(status().isOk())
+				.andExpect(content().string("false"));
+	}
+
+	@Test
+	void isGuardedLocation_returnsFalse_whenNoGuardCoversLocation() throws Exception {
+		jdbcTemplate.update(
+				"INSERT INTO gps_locations (latitude, latitude_ref, longitude, longitude_ref) VALUES (1.00000, 'N', 1.00000, 'E')");
+		Long gpsId = jdbcTemplate.queryForObject("SELECT MAX(id) FROM gps_locations", Long.class);
+		// No guards exist → returns false
+		doGet("/location/guard/" + gpsId)
+				.andExpect(status().isOk())
+				.andExpect(content().string("false"));
+	}
+
+	@Test
+	void isGuardedLocation_returnsTrue_whenSquareGuardCoversLocation() throws Exception {
+		// GPS point at 60.12 N, 24.92 E — falls inside the square below
+		jdbcTemplate.update(
+				"INSERT INTO gps_locations (latitude, latitude_ref, longitude, longitude_ref) VALUES (60.12000, 'N', 24.92000, 'E')");
+		Long gpsId = jdbcTemplate.queryForObject("SELECT MAX(id) FROM gps_locations", Long.class);
+
+		// SQUARE guard: (60.10,24.90) → (60.15,24.95)
+		jdbcTemplate.update(
+				"INSERT INTO location_guard (guard_type, primary_longitude, primary_latitude, secondary_longitude, secondary_latitude) VALUES ('SQUARE', 24.90000, 60.10000, 24.95000, 60.15000)");
+
+		doGet("/location/guard/" + gpsId)
+				.andExpect(status().isOk())
+				.andExpect(content().string("true"));
+	}
+
+	// -----------------------------------------------------------------------
+	// POST /api/location/guard  (create)
+	// -----------------------------------------------------------------------
+
+	@Test
+	void addLocationGuard_circleType_returns200() throws Exception {
+		String body = """
+				{
+				  "guard_type": "CIRCLE",
+				  "primary_coordinate": {"latitude": 60.17, "longitude": 24.94},
+				  "radius": 200
+				}
+				""";
+		doPost("/location/guard", body)
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.id", notNullValue()))
+				.andExpect(jsonPath("$.guard_type", is("CIRCLE")));
+	}
+
+	@Test
+	void addLocationGuard_squareType_returns200() throws Exception {
+		String body = """
+				{
+				  "guard_type": "SQUARE",
+				  "primary_coordinate": {"latitude": 60.10, "longitude": 24.90},
+				  "secondary_coordinate": {"latitude": 60.15, "longitude": 24.95}
+				}
+				""";
+		doPost("/location/guard", body)
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.id", notNullValue()))
+				.andExpect(jsonPath("$.guard_type", is("SQUARE")));
+	}
+
+	@Test
+	void addLocationGuard_returns400_whenGuardTypeIsMissing() throws Exception {
+		// guard_type is @NotNull
+		String body = """
+				{
+				  "primary_coordinate": {"latitude": 60.17, "longitude": 24.94}
+				}
+				""";
+		doPost("/location/guard", body)
+				.andExpect(status().isBadRequest());
+	}
+
+	// -----------------------------------------------------------------------
+	// PUT /api/location/guard  (update)
+	// -----------------------------------------------------------------------
+
+	@Test
+	void updateLocationGuard_returns200_whenGuardExistsAndRequestIsValid() throws Exception {
+		jdbcTemplate.update(
+				"INSERT INTO location_guard (guard_type, primary_longitude, primary_latitude, secondary_longitude, secondary_latitude) VALUES ('SQUARE', 24.90000, 60.10000, 24.95000, 60.15000)");
+		Long guardId = jdbcTemplate.queryForObject("SELECT MAX(id) FROM location_guard", Long.class);
+
+		String updateBody = """
+				{
+				  "id": %d,
+				  "guard_type": "CIRCLE",
+				  "primary_coordinate": {"latitude": 60.17, "longitude": 24.94},
+				  "radius": 150
+				}
+				""".formatted(guardId);
+
+		doPut("/location/guard", updateBody)
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.id", is(guardId.intValue())))
+				.andExpect(jsonPath("$.guard_type", is("CIRCLE")));
+	}
+
+	@Test
+	void updateLocationGuard_returns400_whenIdIsNull() throws Exception {
+		// id=null → LocationService throws IllegalArgumentException → GlobalExceptionHandler → 400
+		String body = """
+				{
+				  "guard_type": "CIRCLE",
+				  "primary_coordinate": {"latitude": 60.17, "longitude": 24.94},
+				  "radius": 100
+				}
+				""";
+		doPut("/location/guard", body)
+				.andExpect(status().isBadRequest());
+	}
+
+	// -----------------------------------------------------------------------
+	// DELETE /api/location/guard/{id}
+	// -----------------------------------------------------------------------
+
+	@Test
+	void deleteLocationGuard_returns204_whenGuardExists() throws Exception {
+		jdbcTemplate.update(
+				"INSERT INTO location_guard (guard_type, primary_longitude, primary_latitude, radius) VALUES ('CIRCLE', 24.93500, 60.17000, 100.00000)");
+		Long guardId = jdbcTemplate.queryForObject("SELECT MAX(id) FROM location_guard", Long.class);
+
+		doDelete("/location/guard/" + guardId)
+				.andExpect(status().isNoContent());
+	}
+
+	@Test
+	void deleteLocationGuard_returns204_whenGuardDoesNotExist() throws Exception {
+		// LocationService logs a warning but still returns normally (no exception)
+		doDelete("/location/guard/99999")
+				.andExpect(status().isNoContent());
+	}
+}
+

--- a/service/src/test/java/fi/poltsi/vempain/file/controller/PathCompletionControllerCTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/controller/PathCompletionControllerCTC.java
@@ -1,0 +1,58 @@
+package fi.poltsi.vempain.file.controller;
+
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Controller Test Class (CTC) for {@link PathCompletionController}.
+ *
+ * <p>Tests the REST endpoint declared in {@code PathCompletionAPI}:
+ * <ul>
+ *   <li>POST /api/path-completion – complete a directory path</li>
+ * </ul>
+ *
+ * <p>The original and export root directories are set to {@code /tmp} in
+ * test properties, so path completions operate on the host's /tmp directory.
+ */
+class PathCompletionControllerCTC extends AbstractControllerCTC {
+
+	// -----------------------------------------------------------------------
+	// POST /api/path-completion
+	// -----------------------------------------------------------------------
+
+	@Test
+	void completePath_returns200_withValidOriginalRequest() throws Exception {
+		// "/" is valid per the pattern and lists sub-directories of /tmp
+		doPost("/path-completion",
+		       "{\"path\":\"/\",\"type\":\"ORIGINAL\"}")
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.completions").isArray());
+	}
+
+	@Test
+	void completePath_returns200_withValidExportedRequest() throws Exception {
+		doPost("/path-completion",
+		       "{\"path\":\"/\",\"type\":\"EXPORTED\"}")
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.completions").isArray());
+	}
+
+	@Test
+	void completePath_returns400_whenPathDoesNotStartWithSlash() throws Exception {
+		// Pattern requires path to start with '/' — "no-slash" violates it
+		doPost("/path-completion",
+		       "{\"path\":\"no-slash\",\"type\":\"ORIGINAL\"}")
+				.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	void completePath_returns400_whenPathIsBlank() throws Exception {
+		// @NotBlank on path field
+		doPost("/path-completion",
+		       "{\"path\":\"\",\"type\":\"ORIGINAL\"}")
+				.andExpect(status().isBadRequest());
+	}
+}
+

--- a/service/src/test/java/fi/poltsi/vempain/file/controller/PublishControllerCTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/controller/PublishControllerCTC.java
@@ -1,0 +1,96 @@
+package fi.poltsi.vempain.file.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Controller Test Class (CTC) for {@link PublishController}.
+ *
+ * <p>Tests all REST endpoints declared in {@code PublishAPI}:
+ * <ul>
+ *   <li>POST /api/publish/file-group      – publish a single file group</li>
+ *   <li>GET  /api/publish/all-file-groups – publish all file groups</li>
+ *   <li>GET  /api/publish/progress        – get publish progress</li>
+ * </ul>
+ *
+ * <p>Publish operations are asynchronous; only HTTP response codes and
+ * response body shape are verified here, not async completion.
+ */
+class PublishControllerCTC extends AbstractControllerCTC {
+
+	@BeforeEach
+	void cleanFileGroups() {
+		jdbcTemplate.execute("TRUNCATE TABLE file_group RESTART IDENTITY CASCADE");
+	}
+
+	// -----------------------------------------------------------------------
+	// POST /api/publish/file-group
+	// -----------------------------------------------------------------------
+
+	@Test
+	void publishFileGroup_returns404_whenFileGroupDoesNotExist() throws Exception {
+		doPost("/publish/file-group",
+		       "{\"file_group_id\":99999}")
+				.andExpect(status().isNotFound());
+	}
+
+	@Test
+	void publishFileGroup_returns202_whenFileGroupExists() throws Exception {
+		// countFilesInGroup uses countById which returns 1 when the group exists
+		jdbcTemplate.update(
+				"INSERT INTO file_group (path, group_name, description) VALUES (?, ?, ?)",
+				"/pub/path", "Publish Group", "A group to publish");
+		Long groupId = jdbcTemplate.queryForObject("SELECT MAX(id) FROM file_group", Long.class);
+
+		doPost("/publish/file-group",
+		       "{\"file_group_id\":" + groupId + ",\"gallery_name\":\"My Gallery\",\"gallery_description\":\"Desc\"}")
+				.andExpect(status().isAccepted())
+				.andExpect(jsonPath("$.files_to_publish_count", notNullValue()));
+	}
+
+	// -----------------------------------------------------------------------
+	// GET /api/publish/all-file-groups
+	// -----------------------------------------------------------------------
+
+	@Test
+	void publishAllFileGroups_returns202_whenNoGroupsExist() throws Exception {
+		doGet("/publish/all-file-groups")
+				.andExpect(status().isAccepted())
+				.andExpect(jsonPath("$.file_groups_count").value(0));
+	}
+
+	@Test
+	void publishAllFileGroups_returns202_withScheduledCount_whenGroupsExist() throws Exception {
+		jdbcTemplate.update(
+				"INSERT INTO file_group (path, group_name, description) VALUES (?,?,?)",
+				"/g1", "Group 1", "desc 1");
+		jdbcTemplate.update(
+				"INSERT INTO file_group (path, group_name, description) VALUES (?,?,?)",
+				"/g2", "Group 2", "desc 2");
+
+		doGet("/publish/all-file-groups")
+				.andExpect(status().isAccepted())
+				.andExpect(jsonPath("$.file_groups_count", greaterThanOrEqualTo(2)));
+	}
+
+	// -----------------------------------------------------------------------
+	// GET /api/publish/progress
+	// -----------------------------------------------------------------------
+
+	@Test
+	void getPublishProgress_returns200_withProgressFields() throws Exception {
+		doGet("/publish/progress")
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.total_groups").exists())
+				.andExpect(jsonPath("$.scheduled").exists())
+				.andExpect(jsonPath("$.started").exists())
+				.andExpect(jsonPath("$.completed").exists())
+				.andExpect(jsonPath("$.failed").exists());
+	}
+}
+

--- a/service/src/test/java/fi/poltsi/vempain/file/controller/RestEndpointsCTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/controller/RestEndpointsCTC.java
@@ -1,0 +1,132 @@
+package fi.poltsi.vempain.file.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = {
+		"vempain.app.frontend-url=http://localhost:3000",
+		"vempain.original-root-directory=/tmp",
+		"vempain.export-root-directory=/tmp"
+})
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class RestEndpointsCTC {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	record EndpointCase(String method, String path, String body, boolean csrf) {
+	}
+
+	@Test
+	void allEndpoints_requireAuthentication_andAreReachableWhenAuthenticated() throws Exception {
+		var cases = List.of(
+				new EndpointCase("POST", "/api/file-groups/paged", "{\"page\":0,\"size\":10}", true),
+				new EndpointCase("GET", "/api/file-groups/1", null, false),
+				new EndpointCase("POST", "/api/file-groups", "{\"path\":\"/p\",\"group_name\":\"g\",\"file_ids\":[]}", true),
+				new EndpointCase("PUT", "/api/file-groups", "{\"id\":1,\"path\":\"/p\",\"group_name\":\"g\",\"file_ids\":[]}", true),
+				new EndpointCase("POST", "/api/scan-files", "{\"original_directory\":\"does-not-exist\"}", true),
+				new EndpointCase("GET", "/api/location/1", null, false),
+				new EndpointCase("GET", "/api/location/guards", null, false),
+				new EndpointCase("GET", "/api/location/guards/1", null, false),
+				new EndpointCase("POST", "/api/location/guards", "{\"guard_type\":\"CIRCLE\",\"primary_coordinate\":{\"latitude\":60.1,\"longitude\":24.9},\"radius\":100}", true),
+				new EndpointCase("PUT", "/api/location/guards", "{\"id\":1,\"guard_type\":\"SQUARE\",\"primary_coordinate\":{\"latitude\":60.1,\"longitude\":24.9},\"secondary_coordinate\":{\"latitude\":60.2,\"longitude\":25.0}}", true),
+				new EndpointCase("DELETE", "/api/location/guards/1", null, true),
+				new EndpointCase("POST", "/api/path-completion", "{\"type\":\"ORIGINAL\",\"path\":\"/\"}", true),
+				new EndpointCase("POST", "/api/publish/file-group", "{\"file_group_id\":1,\"gallery_name\":\"g\",\"gallery_description\":\"d\"}", true),
+				new EndpointCase("GET", "/api/publish/all-file-groups", null, false),
+				new EndpointCase("GET", "/api/publish/progress", null, false),
+				new EndpointCase("GET", "/api/tags", null, false),
+				new EndpointCase("GET", "/api/tags/1", null, false),
+				new EndpointCase("POST", "/api/tags", "{\"tag_name\":\"nature\"}", true),
+				new EndpointCase("PUT", "/api/tags", "{\"id\":1,\"tag_name\":\"nature\"}", true),
+				new EndpointCase("DELETE", "/api/tags/1", null, true),
+				new EndpointCase("POST", "/api/files/archive/paged", "{\"page\":0,\"size\":10}", true),
+				new EndpointCase("GET", "/api/files/archive/1", null, false),
+				new EndpointCase("DELETE", "/api/files/archive/1", null, true),
+				new EndpointCase("POST", "/api/files/audio/paged", "{\"page\":0,\"size\":10}", true),
+				new EndpointCase("GET", "/api/files/audio/1", null, false),
+				new EndpointCase("DELETE", "/api/files/audio/1", null, true),
+				new EndpointCase("POST", "/api/files/binary/paged", "{\"page\":0,\"size\":10}", true),
+				new EndpointCase("GET", "/api/files/binary/1", null, false),
+				new EndpointCase("DELETE", "/api/files/binary/1", null, true),
+				new EndpointCase("POST", "/api/files/data/paged", "{\"page\":0,\"size\":10}", true),
+				new EndpointCase("GET", "/api/files/data/1", null, false),
+				new EndpointCase("DELETE", "/api/files/data/1", null, true),
+				new EndpointCase("POST", "/api/files/document/paged", "{\"page\":0,\"size\":10}", true),
+				new EndpointCase("GET", "/api/files/document/1", null, false),
+				new EndpointCase("DELETE", "/api/files/document/1", null, true),
+				new EndpointCase("POST", "/api/files/executable/paged", "{\"page\":0,\"size\":10}", true),
+				new EndpointCase("GET", "/api/files/executable/1", null, false),
+				new EndpointCase("DELETE", "/api/files/executable/1", null, true),
+				new EndpointCase("POST", "/api/files/font/paged", "{\"page\":0,\"size\":10}", true),
+				new EndpointCase("GET", "/api/files/font/1", null, false),
+				new EndpointCase("DELETE", "/api/files/font/1", null, true),
+				new EndpointCase("POST", "/api/files/icon/paged", "{\"page\":0,\"size\":10}", true),
+				new EndpointCase("GET", "/api/files/icon/1", null, false),
+				new EndpointCase("DELETE", "/api/files/icon/1", null, true),
+				new EndpointCase("POST", "/api/files/image/paged", "{\"page\":0,\"size\":10}", true),
+				new EndpointCase("GET", "/api/files/image/1", null, false),
+				new EndpointCase("DELETE", "/api/files/image/1", null, true),
+				new EndpointCase("POST", "/api/files/interactive/paged", "{\"page\":0,\"size\":10}", true),
+				new EndpointCase("GET", "/api/files/interactive/1", null, false),
+				new EndpointCase("DELETE", "/api/files/interactive/1", null, true),
+				new EndpointCase("POST", "/api/files/thumb/paged", "{\"page\":0,\"size\":10}", true),
+				new EndpointCase("GET", "/api/files/thumb/1", null, false),
+				new EndpointCase("DELETE", "/api/files/thumb/1", null, true),
+				new EndpointCase("POST", "/api/files/vector/paged", "{\"page\":0,\"size\":10}", true),
+				new EndpointCase("GET", "/api/files/vector/1", null, false),
+				new EndpointCase("DELETE", "/api/files/vector/1", null, true),
+				new EndpointCase("POST", "/api/files/video/paged", "{\"page\":0,\"size\":10}", true),
+				new EndpointCase("GET", "/api/files/video/1", null, false),
+				new EndpointCase("DELETE", "/api/files/video/1", null, true)
+		);
+
+		for (var endpoint : cases) {
+			perform(endpoint, false).andExpect(status().is4xxClientError());
+		}
+
+		for (var endpoint : cases) {
+			var result = perform(endpoint, true).andReturn()
+			                                    .getResponse();
+			assertThat(result.getStatus()).isNotEqualTo(401);
+		}
+	}
+
+	private ResultActions perform(EndpointCase endpoint, boolean authenticated) throws Exception {
+		MockHttpServletRequestBuilder builder = switch (endpoint.method()) {
+			case "GET" -> MockMvcRequestBuilders.get(endpoint.path());
+			case "POST" -> MockMvcRequestBuilders.post(endpoint.path());
+			case "PUT" -> MockMvcRequestBuilders.put(endpoint.path());
+			case "DELETE" -> MockMvcRequestBuilders.delete(endpoint.path());
+			default -> throw new IllegalArgumentException("Unsupported method " + endpoint.method());
+		};
+
+		if (authenticated) {
+			builder = builder.with(user("ctc-user").roles("USER"));
+		}
+		if (endpoint.csrf()) {
+			builder = builder.with(csrf());
+		}
+		if (endpoint.body() != null) {
+			builder.contentType(MediaType.APPLICATION_JSON)
+			       .content(endpoint.body());
+		}
+		return mockMvc.perform(builder);
+	}
+}

--- a/service/src/test/java/fi/poltsi/vempain/file/controller/TagControllerCTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/controller/TagControllerCTC.java
@@ -1,0 +1,188 @@
+package fi.poltsi.vempain.file.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Controller Test Class (CTC) for {@link TagController}.
+ *
+ * <p>Tests all REST endpoints declared in {@code TagAPI}:
+ * <ul>
+ *   <li>GET    /api/tags      – list all tags</li>
+ *   <li>GET    /api/tags/{id} – single tag</li>
+ *   <li>POST   /api/tags      – create</li>
+ *   <li>PUT    /api/tags      – update</li>
+ *   <li>DELETE /api/tags/{id} – delete</li>
+ * </ul>
+ */
+class TagControllerCTC extends AbstractControllerCTC {
+
+	private static final String VALID_TAG_BODY = """
+			{
+			  "tag_name": "nature",
+			  "tag_name_de": "Natur",
+			  "tag_name_en": "nature",
+			  "tag_name_es": "naturaleza",
+			  "tag_name_fi": "luonto",
+			  "tag_name_sv": "natur"
+			}
+			""";
+
+	@BeforeEach
+	void cleanTags() {
+		// file_tags has FK to tags; CASCADE removes it
+		jdbcTemplate.execute("TRUNCATE TABLE tags RESTART IDENTITY CASCADE");
+	}
+
+	// -----------------------------------------------------------------------
+	// GET /api/tags
+	// -----------------------------------------------------------------------
+
+	@Test
+	void getAllTags_returnsEmptyList_whenNoTagsExist() throws Exception {
+		doGet("/tags")
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$").isArray())
+				.andExpect(jsonPath("$", hasSize(0)));
+	}
+
+	@Test
+	void getAllTags_returnsListWithTags_whenTagsExist() throws Exception {
+		jdbcTemplate.update(
+				"INSERT INTO tags (tag_name, tag_name_de, tag_name_en, tag_name_es, tag_name_fi, tag_name_sv) VALUES (?,?,?,?,?,?)",
+				"animal", "Tier", "animal", "animal", "eläin", "djur");
+		jdbcTemplate.update(
+				"INSERT INTO tags (tag_name, tag_name_de, tag_name_en, tag_name_es, tag_name_fi, tag_name_sv) VALUES (?,?,?,?,?,?)",
+				"landscape", "Landschaft", "landscape", "paisaje", "maisema", "landskap");
+
+		doGet("/tags")
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$").isArray())
+				.andExpect(jsonPath("$", hasSize(2)));
+	}
+
+	// -----------------------------------------------------------------------
+	// GET /api/tags/{id}
+	// -----------------------------------------------------------------------
+
+	@Test
+	void getTagById_returns200_whenTagExists() throws Exception {
+		jdbcTemplate.update(
+				"INSERT INTO tags (tag_name, tag_name_de, tag_name_en, tag_name_es, tag_name_fi, tag_name_sv) VALUES (?,?,?,?,?,?)",
+				"flower", "Blume", "flower", "flor", "kukka", "blomma");
+		Long id = jdbcTemplate.queryForObject("SELECT MAX(id) FROM tags", Long.class);
+
+		doGet("/tags/" + id)
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.id", is(id.intValue())))
+				.andExpect(jsonPath("$.tag_name", is("flower")));
+	}
+
+	@Test
+	void getTagById_returns400_whenTagNotFound() throws Exception {
+		// TagService throws IllegalArgumentException("Tag not found") → GlobalExceptionHandler → 400
+		doGet("/tags/99999")
+				.andExpect(status().isBadRequest());
+	}
+
+	// -----------------------------------------------------------------------
+	// POST /api/tags  (create)
+	// -----------------------------------------------------------------------
+
+	@Test
+	void createTag_returns200_whenRequestIsValid() throws Exception {
+		doPost("/tags", VALID_TAG_BODY)
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.id", notNullValue()))
+				.andExpect(jsonPath("$.tag_name", is("nature")));
+	}
+
+	@Test
+	void createTag_returns400_whenTagNameIsBlank() throws Exception {
+		// tag_name is @NotBlank
+		doPost("/tags",
+		       "{\"tag_name\":\"\",\"tag_name_de\":\"d\",\"tag_name_en\":\"e\",\"tag_name_es\":\"e\",\"tag_name_fi\":\"f\",\"tag_name_sv\":\"s\"}")
+				.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	void createTag_returns400_whenRequiredFieldsMissing() throws Exception {
+		// Missing tag_name_de, tag_name_en, tag_name_es, tag_name_fi, tag_name_sv
+		doPost("/tags", "{\"tag_name\":\"test\"}")
+				.andExpect(status().isBadRequest());
+	}
+
+	// -----------------------------------------------------------------------
+	// PUT /api/tags  (update)
+	// -----------------------------------------------------------------------
+
+	@Test
+	void updateTag_returns200_whenTagExistsAndRequestIsValid() throws Exception {
+		jdbcTemplate.update(
+				"INSERT INTO tags (tag_name, tag_name_de, tag_name_en, tag_name_es, tag_name_fi, tag_name_sv) VALUES (?,?,?,?,?,?)",
+				"sky", "Himmel", "sky", "cielo", "taivas", "himmel");
+		Long id = jdbcTemplate.queryForObject("SELECT MAX(id) FROM tags", Long.class);
+
+		String updateBody = """
+				{
+				  "id": %d,
+				  "tag_name": "blue-sky",
+				  "tag_name_de": "Blauer Himmel",
+				  "tag_name_en": "blue sky",
+				  "tag_name_es": "cielo azul",
+				  "tag_name_fi": "sininen taivas",
+				  "tag_name_sv": "blå himmel"
+				}
+				""".formatted(id);
+
+		doPut("/tags", updateBody)
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.tag_name", is("blue-sky")));
+	}
+
+	@Test
+	void updateTag_returns400_whenIdIsNullInRequest() throws Exception {
+		// id=null → service throws IllegalArgumentException → GlobalExceptionHandler → 400
+		String body = """
+				{
+				  "tag_name": "updated",
+				  "tag_name_de": "aktualisiert",
+				  "tag_name_en": "updated",
+				  "tag_name_es": "actualizado",
+				  "tag_name_fi": "päivitetty",
+				  "tag_name_sv": "uppdaterad"
+				}
+				""";
+		doPut("/tags", body)
+				.andExpect(status().isBadRequest());
+	}
+
+	// -----------------------------------------------------------------------
+	// DELETE /api/tags/{id}
+	// -----------------------------------------------------------------------
+
+	@Test
+	void deleteTag_returns204_whenTagExists() throws Exception {
+		jdbcTemplate.update(
+				"INSERT INTO tags (tag_name, tag_name_de, tag_name_en, tag_name_es, tag_name_fi, tag_name_sv) VALUES (?,?,?,?,?,?)",
+				"delete-me", "Löschen", "delete", "eliminar", "poista", "radera");
+		Long id = jdbcTemplate.queryForObject("SELECT MAX(id) FROM tags", Long.class);
+
+		doDelete("/tags/" + id)
+				.andExpect(status().isNoContent());
+	}
+
+	@Test
+	void deleteTag_returns204_whenTagDoesNotExist() throws Exception {
+		// deleteById does not throw if entity is missing in JPA default impl
+		doDelete("/tags/99999")
+				.andExpect(status().isNoContent());
+	}
+}
+

--- a/service/src/test/java/fi/poltsi/vempain/file/controller/files/FileTypeControllersCTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/controller/files/FileTypeControllersCTC.java
@@ -1,0 +1,202 @@
+package fi.poltsi.vempain.file.controller.files;
+
+import fi.poltsi.vempain.file.controller.AbstractControllerCTC;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Controller Test Class (CTC) covering all 13 typed-file controllers.
+ *
+ * <p>Each file type exposes three endpoints via its API interface:
+ * <ul>
+ *   <li>POST /api/files/{type}/paged  – paged list</li>
+ *   <li>GET  /api/files/{type}/{id}   – single record</li>
+ *   <li>DELETE /api/files/{type}/{id} – remove</li>
+ * </ul>
+ *
+ * <p>All tests are parameterized via {@link #fileTypeArgs()} so that every
+ * type is exercised with the same four test scenarios:
+ * <ol>
+ *   <li>findAll returns 200 with valid page structure</li>
+ *   <li>findById returns 404 for a missing id</li>
+ *   <li>findById returns 200 for a seeded record</li>
+ *   <li>delete returns 200 for a seeded record</li>
+ * </ol>
+ *
+ * <p>Test records are seeded with id=9001 and cleaned up after each test.
+ * The Flyway-seeded document file (id=1) is not touched.
+ */
+class FileTypeControllersCTC extends AbstractControllerCTC {
+
+	// -----------------------------------------------------------------------
+	// Argument source — one entry per file type
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Arguments: (urlSegment, fileType, mimeType, filename, filePath, typeInsertSql)
+	 */
+	static Stream<Arguments> fileTypeArgs() {
+		return Stream.of(
+				Arguments.of(
+						"archive", "ARCHIVE", "application/zip",
+						"test-file.zip", "/test/archive",
+						"INSERT INTO archive_files (id, compression_method, uncompressed_size, content_count, is_encrypted) VALUES (9001, 'zip', 2048, 5, false)"
+				),
+				Arguments.of(
+						"audio", "AUDIO", "audio/mpeg",
+						"test-file.mp3", "/test/audio",
+						"INSERT INTO audio_files (id, duration, bit_rate, sample_rate, codec, channels) VALUES (9001, 180, 192000, 44100, 'MP3', 2)"
+				),
+				Arguments.of(
+						"binary", "BINARY", "application/octet-stream",
+						"test-file.bin", "/test/binary",
+						"INSERT INTO binary_files (id, software_name, software_major_version) VALUES (9001, 'TestApp', 1)"
+				),
+				Arguments.of(
+						"data", "DATA", "text/csv",
+						"test-file.csv", "/test/data",
+						"INSERT INTO data_files (id, data_structure) VALUES (9001, 'CSV')"
+				),
+				Arguments.of(
+						"document", "DOCUMENT", "application/pdf",
+						"test-file.pdf", "/test/document",
+						"INSERT INTO document_files (id, page_count, format) VALUES (9001, 10, 'PDF')"
+				),
+				Arguments.of(
+						"executable", "EXECUTABLE", "application/x-executable",
+						"test-file.sh", "/test/executable",
+						"INSERT INTO executable_files (id, is_script) VALUES (9001, true)"
+				),
+				Arguments.of(
+						"font", "FONT", "font/ttf",
+						"test-file.ttf", "/test/font",
+						"INSERT INTO font_files (id, font_family, weight, style) VALUES (9001, 'TestFont', 'regular', 'normal')"
+				),
+				Arguments.of(
+						"icon", "ICON", "image/x-icon",
+						"test-file.ico", "/test/icon",
+						"INSERT INTO icon_files (id, width, height, is_scalable) VALUES (9001, 64, 64, false)"
+				),
+				Arguments.of(
+						"image", "IMAGE", "image/jpeg",
+						"test-file.jpg", "/test/image",
+						"INSERT INTO image_files (id, width, height, color_depth, dpi, group_label) VALUES (9001, 1920, 1080, 24, 72, 'test-group')"
+				),
+				Arguments.of(
+						"interactive", "INTERACTIVE", "text/html",
+						"test-file.html", "/test/interactive",
+						"INSERT INTO interactive_files (id, technology) VALUES (9001, 'HTML5')"
+				),
+				Arguments.of(
+						"thumb", "THUMB", "image/jpeg",
+						"test-thumb.jpg", "/test/thumb",
+						"INSERT INTO thumb_files (id, target_file_id, relation_type) VALUES (9001, NULL, 'thumbnail')"
+				),
+				Arguments.of(
+						"vector", "VECTOR", "image/svg+xml",
+						"test-file.svg", "/test/vector",
+						"INSERT INTO vector_files (id, width, height, layers_count) VALUES (9001, 800, 600, 3)"
+				),
+				Arguments.of(
+						"video", "VIDEO", "video/mp4",
+						"test-file.mp4", "/test/video",
+						"INSERT INTO video_files (id, width, height, frame_rate, duration, codec) VALUES (9001, 1920, 1080, 25.0, 120, 'H264')"
+				)
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// Test 1: findAll returns 200 with valid paged response shape
+	// -----------------------------------------------------------------------
+
+	@ParameterizedTest(name = "[{index}] findAll({0})")
+	@MethodSource("fileTypeArgs")
+	void findAll_returns200WithValidPageShape(
+			String urlSegment, String fileType, String mimeType,
+			String filename, String filePath, String typeInsertSql) throws Exception {
+
+		doPost("/files/" + urlSegment + "/paged", "{\"page\":0,\"size\":10}")
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.content").isArray());
+	}
+
+	// -----------------------------------------------------------------------
+	// Test 2: findById returns 404 for a missing id
+	// -----------------------------------------------------------------------
+
+	@ParameterizedTest(name = "[{index}] findById_404({0})")
+	@MethodSource("fileTypeArgs")
+	void findById_returns404_whenRecordDoesNotExist(
+			String urlSegment, String fileType, String mimeType,
+			String filename, String filePath, String typeInsertSql) throws Exception {
+
+		doGet("/files/" + urlSegment + "/99999")
+				.andExpect(status().isNotFound());
+	}
+
+	// -----------------------------------------------------------------------
+	// Test 3: findById returns 200 for a seeded record
+	// -----------------------------------------------------------------------
+
+	@ParameterizedTest(name = "[{index}] findById_200({0})")
+	@MethodSource("fileTypeArgs")
+	void findById_returns200_whenRecordExists(
+			String urlSegment, String fileType, String mimeType,
+			String filename, String filePath, String typeInsertSql) throws Exception {
+
+		seedFileRow(9001L, fileType, mimeType, filename, filePath);
+		jdbcTemplate.update(typeInsertSql);
+
+		try {
+			doGet("/files/" + urlSegment + "/9001")
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.id").value(9001))
+					.andExpect(jsonPath("$.file_type").value(fileType));
+		} finally {
+			deleteFileRow(9001L);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Test 4: delete returns 200 for a seeded record
+	// -----------------------------------------------------------------------
+
+	@ParameterizedTest(name = "[{index}] delete_200({0})")
+	@MethodSource("fileTypeArgs")
+	void delete_returns200_whenRecordExists(
+			String urlSegment, String fileType, String mimeType,
+			String filename, String filePath, String typeInsertSql) throws Exception {
+
+		seedFileRow(9001L, fileType, mimeType, filename, filePath);
+		jdbcTemplate.update(typeInsertSql);
+
+		try {
+			doDelete("/files/" + urlSegment + "/9001")
+					.andExpect(status().isOk());
+		} finally {
+			// cleanup in case delete did not succeed
+			jdbcTemplate.update("DELETE FROM files WHERE id = 9001");
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Test 5: delete returns 404 for a missing id
+	// -----------------------------------------------------------------------
+
+	@ParameterizedTest(name = "[{index}] delete_404({0})")
+	@MethodSource("fileTypeArgs")
+	void delete_returns404_whenRecordDoesNotExist(
+			String urlSegment, String fileType, String mimeType,
+			String filename, String filePath, String typeInsertSql) throws Exception {
+
+		doDelete("/files/" + urlSegment + "/99999")
+				.andExpect(status().isNotFound());
+	}
+}
+

--- a/service/src/test/java/fi/poltsi/vempain/file/service/AllCoreServicesUTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/service/AllCoreServicesUTC.java
@@ -1,0 +1,225 @@
+package fi.poltsi.vempain.file.service;
+
+import feign.Request;
+import feign.RequestTemplate;
+import feign.Response;
+import fi.poltsi.vempain.admin.api.request.file.FileIngestRequest;
+import fi.poltsi.vempain.auth.exception.VempainAuthenticationException;
+import fi.poltsi.vempain.file.api.PathCompletionEnum;
+import fi.poltsi.vempain.file.api.request.PathCompletionRequest;
+import fi.poltsi.vempain.file.api.request.ScanRequest;
+import fi.poltsi.vempain.file.entity.ExportFileEntity;
+import fi.poltsi.vempain.file.entity.TagEntity;
+import fi.poltsi.vempain.file.feign.VempainAdminFileIngestClient;
+import fi.poltsi.vempain.file.repository.ExportFileRepository;
+import fi.poltsi.vempain.file.repository.FileGroupRepository;
+import fi.poltsi.vempain.file.repository.FileTagRepository;
+import fi.poltsi.vempain.file.repository.GpsLocationRepository;
+import fi.poltsi.vempain.file.repository.MetadataRepository;
+import fi.poltsi.vempain.file.repository.TagRepository;
+import fi.poltsi.vempain.file.repository.files.FileRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AllCoreServicesUTC {
+
+	@Mock
+	private ExportFileRepository                                   exportFileRepository;
+	@Mock
+	private FileRepository                                         fileRepository;
+	@Mock
+	private TagRepository                                          tagRepository;
+	@Mock
+	private FileTagRepository                                      fileTagRepository;
+	@Mock
+	private FileGroupRepository                                    fileGroupRepository;
+	@Mock
+	private MetadataRepository                                     metadataRepository;
+	@Mock
+	private VempainAdminService                                    vempainAdminService;
+	@Mock
+	private TagService                                             tagService;
+	@Mock
+	private LocationService                                        locationService;
+	@Mock
+	private fi.poltsi.vempain.file.feign.VempainAdminTokenProvider tokenProvider;
+	@Mock
+	private fi.poltsi.vempain.file.tools.ImageTool                 imageTool;
+	@Mock
+	private org.springframework.context.ApplicationContext         applicationContext;
+	@Mock
+	private fi.poltsi.vempain.file.repository.FileTagRepository    fileTagRepo;
+	@Mock
+	private fi.poltsi.vempain.file.repository.FileGroupRepository  fgRepo;
+	@Mock
+	private fi.poltsi.vempain.file.repository.files.FileRepository fileRepo;
+	@Mock
+	private fi.poltsi.vempain.file.repository.TagRepository        tagRepo;
+	@Mock
+	private fi.poltsi.vempain.file.repository.MetadataRepository   metaRepo;
+	@Mock
+	private fi.poltsi.vempain.file.repository.ExportFileRepository expRepo;
+	@Mock
+	private fi.poltsi.vempain.auth.service.AclService              aclService;
+	@Mock
+	private ExportedFilesService                                   exportedFilesService;
+	@Mock
+	private GpsLocationRepository                                  gpsLocationRepository;
+	@Mock
+	private VempainAdminFileIngestClient                           ingestClient;
+	@Mock
+	private ObjectMapper                                           objectMapper;
+	@Mock
+	private DirectoryProcessorService                              directoryProcessorService;
+
+	@Test
+	void exportedFilesServiceUTC() {
+		var service = new ExportedFilesService(exportFileRepository);
+		when(exportFileRepository.findByFilePathAndFilename("/x", "a.jpg")).thenReturn(Optional.empty());
+		assertThat(service.existsByPathAndFilename("/x", "a.jpg")).isFalse();
+
+		when(exportFileRepository.findByOriginalDocumentId("doc-1")).thenReturn(new ExportFileEntity());
+		assertThat(service.existsByOriginalDocumentId("doc-1")).isTrue();
+
+		var entity = new ExportFileEntity();
+		when(exportFileRepository.save(entity)).thenReturn(entity);
+		assertThat(service.save(entity)).isSameAs(entity);
+	}
+
+	@Test
+	void derivativeLookupServiceUTC_usesDatabaseMatch() {
+		var service = new DerivativeLookupService(exportFileRepository, fileRepository);
+		ReflectionTestUtils.setField(service, "exportDirectory", "/tmp/export");
+		var mockFileEntity = org.mockito.Mockito.mock(fi.poltsi.vempain.file.entity.FileEntity.class);
+		when(mockFileEntity.getFilePath()).thenReturn("/path");
+		when(mockFileEntity.getFilename()).thenReturn("name.jpg");
+		when(fileRepository.findByOriginalDocumentId("doc-1")).thenReturn(mockFileEntity);
+
+		var result = service.findOriginal("/any", "name.jpg", "doc-1");
+		assertThat(result).isNotNull();
+	}
+
+	@Test
+	void pathCompletionServiceUTC_listsSubDirectories() throws IOException {
+		var root  = Files.createTempDirectory("path-completion-root");
+		var child = root.resolve("album");
+		Files.createDirectories(child);
+		var service = new PathCompletionService();
+		ReflectionTestUtils.setField(service, "originalRootDirectory", root.toString());
+		ReflectionTestUtils.setField(service, "exportedRootDirectory", root.toString());
+
+		var request  = new PathCompletionRequest("/", PathCompletionEnum.ORIGINAL);
+		var response = service.completePath(request);
+		assertThat(response.getCompletions()).contains("/album");
+	}
+
+	@Test
+	void fileScannerServiceUTC_returnsResponse() {
+		var service = new FileScannerService(directoryProcessorService);
+		ReflectionTestUtils.setField(service, "originalRootDirectory", "/tmp");
+		ReflectionTestUtils.setField(service, "exportRootDirectory", "/tmp");
+
+		var request  = new ScanRequest();
+		var response = service.scanDirectories(request);
+		assertThat(response).isNotNull();
+	}
+
+	@Test
+	void publishProgressStoreUTC_tracksCounters() {
+		var store = new PublishProgressStore();
+		store.init(2);
+		store.markScheduled(1L);
+		store.markStarted(1L);
+		store.markCompleted(1L);
+		store.markFailed(2L);
+
+		assertThat(store.getTotal()).isEqualTo(2);
+		assertThat(store.getScheduled()).isEqualTo(1);
+		assertThat(store.getStarted()).isEqualTo(1);
+		assertThat(store.getCompleted()).isEqualTo(1);
+		assertThat(store.getFailed()).isEqualTo(1);
+		assertThat(store.getPerGroupStatus()).hasSize(2);
+	}
+
+	@Test
+	void tagServiceUTC_getAllMapsEntities() {
+		var service = new TagService(tagRepository, fileTagRepository);
+		var tag     = TagEntity.builder()
+		                       .id(1L)
+		                       .tagName("nature")
+		                       .build();
+		when(tagRepository.findAll()).thenReturn(List.of(tag));
+
+		var result = service.getAllTags();
+		assertThat(result).hasSize(1);
+		assertThat(result.getFirst()
+		                 .getTagName()).isEqualTo("nature");
+	}
+
+	@Test
+	void fileGroupServiceUTC_getByIdNotFound() {
+		var service = new FileGroupService(fileGroupRepository, fileRepository);
+		when(fileGroupRepository.findById(999L)).thenReturn(Optional.empty());
+		assertThrows(org.springframework.web.server.ResponseStatusException.class, () -> service.getById(999L));
+	}
+
+	@Test
+	void publishServiceUTC_countFilesInGroup() {
+		var service = new PublishService(fileGroupRepository, exportFileRepository, metadataRepository, vempainAdminService,
+		                                 tagService, locationService, tokenProvider, imageTool, applicationContext, new PublishProgressStore());
+		when(fileGroupRepository.countById(10L)).thenReturn(7L);
+		assertThat(service.countFilesInGroup(10L)).isEqualTo(7L);
+	}
+
+	@Test
+	void vempainAdminServiceUTC_throwsOnNon2xx() {
+		var service = new VempainAdminService(ingestClient, objectMapper);
+		var request = FileIngestRequest.builder()
+		                               .fileName("a.jpg")
+		                               .mimeType("image/jpeg")
+		                               .build();
+		when(objectMapper.writeValueAsString(any(FileIngestRequest.class))).thenReturn("{}");
+		var feignRequest = Request.create(Request.HttpMethod.POST, "/ingest", Map.of(), Request.Body.empty(), new RequestTemplate());
+		var response     = Response.builder()
+		                           .request(feignRequest)
+		                           .status(500)
+		                           .reason("error")
+		                           .headers(Map.of())
+		                           .build();
+		when(ingestClient.ingest(any(), any())).thenReturn(ResponseEntity.status(500)
+		                                                                 .build());
+
+		assertThrows(VempainAuthenticationException.class, () -> service.uploadAsSiteFile(Path.of("/tmp/no-file.jpg")
+		                                                                                      .toFile(), request));
+	}
+
+	@Test
+	void directoryProcessorServiceUTC_emptyDirectoryReturnsZeroCounts() throws IOException {
+		var service = new DirectoryProcessorService(fgRepo, fileRepo, tagRepo, metaRepo, fileTagRepo, expRepo, aclService, exportedFilesService, gpsLocationRepository);
+		var dir     = Files.createTempDirectory("empty-original");
+		ReflectionTestUtils.setField(service, "originalRootDirectory", dir.getParent()
+		                                                                  .toString());
+		var result = service.processOriginalDirectory(dir, new StringBuilder(), new java.util.ArrayList<>(), new java.util.ArrayList<>());
+		assertThat(result.getFirst()).isEqualTo(0L);
+		assertThat(result.get(1)).isEqualTo(0L);
+	}
+}
+

--- a/service/src/test/java/fi/poltsi/vempain/file/service/LocationServiceITC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/service/LocationServiceITC.java
@@ -23,6 +23,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import java.util.Optional;
 
@@ -64,7 +65,8 @@ class LocationServiceITC {
 
 	@BeforeEach
 	void resetMocks() {
-		reset(locationRepository, locationGuardRepository);
+		reset(locationRepository);
+		reset(locationGuardRepository);
 	}
 
 	@Nested
@@ -163,8 +165,8 @@ class LocationServiceITC {
 			verify(locationGuardRepository).save(captor.capture());
 			var toSave = captor.getValue();
 			assertThat(toSave.getGuardType()).isEqualTo(GuardTypeEnum.CIRCLE);
-			assertThat(toSave.getPrimaryLatitude()).isEqualTo(valueOf(60.16952).setScale(5, BigDecimal.ROUND_HALF_UP));
-			assertThat(toSave.getPrimaryLongitude()).isEqualTo(valueOf(24.93545).setScale(5, BigDecimal.ROUND_HALF_UP));
+			assertThat(toSave.getPrimaryLatitude()).isEqualTo(valueOf(60.16952).setScale(5, RoundingMode.HALF_UP));
+			assertThat(toSave.getPrimaryLongitude()).isEqualTo(valueOf(24.93545).setScale(5, RoundingMode.HALF_UP));
 		}
 
 		@Test

--- a/service/src/test/java/fi/poltsi/vempain/file/service/files/FileSearchHelperUTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/service/files/FileSearchHelperUTC.java
@@ -1,0 +1,53 @@
+package fi.poltsi.vempain.file.service.files;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FileSearchHelperUTC {
+
+	@Test
+	void buildSpecification_returnsNull_forEmptySearch() {
+		assertThat(FileSearchHelper.buildSpecification(null, false)).isNull();
+		assertThat(FileSearchHelper.buildSpecification("", false)).isNull();
+		assertThat(FileSearchHelper.buildSpecification("   ", true)).isNull();
+	}
+
+	@Test
+	void buildSpecification_returnsSpecification_forNonEmptySearch() {
+		var spec = FileSearchHelper.buildSpecification("holiday photo", false);
+		assertThat(spec).isNotNull();
+	}
+
+	@Test
+	void buildSort_mapsKnownFields() {
+		assertThat(FileSearchHelper.buildSort("id", Sort.Direction.DESC)
+		                           .toString()).contains("id: DESC");
+		assertThat(FileSearchHelper.buildSort("filename", Sort.Direction.ASC)
+		                           .toString()).contains("filename: ASC");
+		assertThat(FileSearchHelper.buildSort("file_path", Sort.Direction.ASC)
+		                           .toString()).contains("filePath: ASC");
+		assertThat(FileSearchHelper.buildSort("filepath", Sort.Direction.DESC)
+		                           .toString()).contains("filePath: DESC");
+		assertThat(FileSearchHelper.buildSort("description", Sort.Direction.ASC)
+		                           .toString()).contains("description: ASC");
+		assertThat(FileSearchHelper.buildSort("mimetype", Sort.Direction.ASC)
+		                           .toString()).contains("mimetype: ASC");
+		assertThat(FileSearchHelper.buildSort("filesize", Sort.Direction.ASC)
+		                           .toString()).contains("filesize: ASC");
+		assertThat(FileSearchHelper.buildSort("created", Sort.Direction.ASC)
+		                           .toString()).contains("created: ASC");
+		assertThat(FileSearchHelper.buildSort("modified", Sort.Direction.ASC)
+		                           .toString()).contains("modified: ASC");
+	}
+
+	@Test
+	void buildSort_defaultsToFilenameAsc_forUnknownInputs() {
+		assertThat(FileSearchHelper.buildSort(null, null)
+		                           .toString()).contains("filename: ASC");
+		assertThat(FileSearchHelper.buildSort("unknown", null)
+		                           .toString()).contains("filename: ASC");
+	}
+}
+

--- a/service/src/test/java/fi/poltsi/vempain/file/service/files/FileTypeServicesITC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/service/files/FileTypeServicesITC.java
@@ -1,0 +1,70 @@
+package fi.poltsi.vempain.file.service.files;
+
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties = {
+		"vempain.app.frontend-url=http://localhost:3000",
+		"vempain.original-root-directory=/tmp",
+		"vempain.export-root-directory=/tmp"
+})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class FileTypeServicesITC {
+
+	@Autowired
+	private ArchiveFileService     archiveFileService;
+	@Autowired
+	private AudioFileService       audioFileService;
+	@Autowired
+	private BinaryFileService      binaryFileService;
+	@Autowired
+	private DataFileService        dataFileService;
+	@Autowired
+	private DocumentFileService    documentFileService;
+	@Autowired
+	private ExecutableFileService  executableFileService;
+	@Autowired
+	private FontFileService        fontFileService;
+	@Autowired
+	private IconFileService        iconFileService;
+	@Autowired
+	private ImageFileService       imageFileService;
+	@Autowired
+	private InteractiveFileService interactiveFileService;
+	@Autowired
+	private ThumbFileService       thumbFileService;
+	@Autowired
+	private VectorFileService      vectorFileService;
+	@Autowired
+	private VideoFileService       videoFileService;
+
+	@Test
+	void findAll_worksAcrossAllFileTypeServices() {
+		var req = new PagedRequest();
+		req.setPage(0);
+		req.setSize(10);
+		req.setSearch("sample");
+		req.setCaseSensitive(Boolean.FALSE);
+		req.setSortBy("filename");
+		req.setDirection(org.springframework.data.domain.Sort.Direction.ASC);
+
+		assertThat(archiveFileService.findAll(req)).isNotNull();
+		assertThat(audioFileService.findAll(req)).isNotNull();
+		assertThat(binaryFileService.findAll(req)).isNotNull();
+		assertThat(dataFileService.findAll(req)).isNotNull();
+		assertThat(documentFileService.findAll(req)).isNotNull();
+		assertThat(executableFileService.findAll(req)).isNotNull();
+		assertThat(fontFileService.findAll(req)).isNotNull();
+		assertThat(iconFileService.findAll(req)).isNotNull();
+		assertThat(imageFileService.findAll(req)).isNotNull();
+		assertThat(interactiveFileService.findAll(req)).isNotNull();
+		assertThat(thumbFileService.findAll(req)).isNotNull();
+		assertThat(vectorFileService.findAll(req)).isNotNull();
+		assertThat(videoFileService.findAll(req)).isNotNull();
+	}
+}

--- a/service/src/test/java/fi/poltsi/vempain/file/service/files/FileTypeServicesUTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/service/files/FileTypeServicesUTC.java
@@ -1,0 +1,277 @@
+package fi.poltsi.vempain.file.service.files;
+
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
+import fi.poltsi.vempain.file.repository.DocumentFileRepository;
+import fi.poltsi.vempain.file.repository.files.ArchiveFileRepository;
+import fi.poltsi.vempain.file.repository.files.AudioFileRepository;
+import fi.poltsi.vempain.file.repository.files.BinaryFileRepository;
+import fi.poltsi.vempain.file.repository.files.DataFileRepository;
+import fi.poltsi.vempain.file.repository.files.ExecutableFileRepository;
+import fi.poltsi.vempain.file.repository.files.FontFileRepository;
+import fi.poltsi.vempain.file.repository.files.IconFileRepository;
+import fi.poltsi.vempain.file.repository.files.ImageFileRepository;
+import fi.poltsi.vempain.file.repository.files.InteractiveFileRepository;
+import fi.poltsi.vempain.file.repository.files.ThumbFileRepository;
+import fi.poltsi.vempain.file.repository.files.VectorFileRepository;
+import fi.poltsi.vempain.file.repository.files.VideoFileRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Page;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.http.HttpStatus;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class FileTypeServicesUTC {
+
+	@Mock
+	private ArchiveFileRepository     archiveFileRepository;
+	@Mock
+	private AudioFileRepository       audioFileRepository;
+	@Mock
+	private BinaryFileRepository      binaryFileRepository;
+	@Mock
+	private DataFileRepository        dataFileRepository;
+	@Mock
+	private DocumentFileRepository    documentFileRepository;
+	@Mock
+	private ExecutableFileRepository  executableFileRepository;
+	@Mock
+	private FontFileRepository        fontFileRepository;
+	@Mock
+	private IconFileRepository        iconFileRepository;
+	@Mock
+	private ImageFileRepository       imageFileRepository;
+	@Mock
+	private InteractiveFileRepository interactiveFileRepository;
+	@Mock
+	private ThumbFileRepository       thumbFileRepository;
+	@Mock
+	private VectorFileRepository      vectorFileRepository;
+	@Mock
+	private VideoFileRepository       videoFileRepository;
+
+	@Test
+	void findById_returnsNull_whenMissing_forAllFileTypeServices() {
+		when(archiveFileRepository.findById(1L)).thenReturn(Optional.empty());
+		when(audioFileRepository.findById(1L)).thenReturn(Optional.empty());
+		when(binaryFileRepository.findById(1L)).thenReturn(Optional.empty());
+		when(dataFileRepository.findById(1L)).thenReturn(Optional.empty());
+		when(documentFileRepository.findById(1L)).thenReturn(Optional.empty());
+		when(executableFileRepository.findById(1L)).thenReturn(Optional.empty());
+		when(fontFileRepository.findById(1L)).thenReturn(Optional.empty());
+		when(iconFileRepository.findById(1L)).thenReturn(Optional.empty());
+		when(imageFileRepository.findById(1L)).thenReturn(Optional.empty());
+		when(interactiveFileRepository.findById(1L)).thenReturn(Optional.empty());
+		when(thumbFileRepository.findById(1L)).thenReturn(Optional.empty());
+		when(vectorFileRepository.findById(1L)).thenReturn(Optional.empty());
+		when(videoFileRepository.findById(1L)).thenReturn(Optional.empty());
+
+		assertThat(new ArchiveFileService(archiveFileRepository).findById(1L)).isNull();
+		assertThat(new AudioFileService(audioFileRepository).findById(1L)).isNull();
+		assertThat(new BinaryFileService(binaryFileRepository).findById(1L)).isNull();
+		assertThat(new DataFileService(dataFileRepository).findById(1L)).isNull();
+		assertThat(new DocumentFileService(documentFileRepository).findById(1L)).isNull();
+		assertThat(new ExecutableFileService(executableFileRepository).findById(1L)).isNull();
+		assertThat(new FontFileService(fontFileRepository).findById(1L)).isNull();
+		assertThat(new IconFileService(iconFileRepository).findById(1L)).isNull();
+		assertThat(new ImageFileService(imageFileRepository).findById(1L)).isNull();
+		assertThat(new InteractiveFileService(interactiveFileRepository).findById(1L)).isNull();
+		assertThat(new ThumbFileService(thumbFileRepository).findById(1L)).isNull();
+		assertThat(new VectorFileService(vectorFileRepository).findById(1L)).isNull();
+		assertThat(new VideoFileService(videoFileRepository).findById(1L)).isNull();
+	}
+
+	@Test
+	void findAll_returnsPagedResponse_forAllFileTypeServices() {
+		var pagedRequest = new PagedRequest();
+		pagedRequest.setPage(0);
+		pagedRequest.setSize(10);
+		pagedRequest.setSearch("file");
+
+		Page<?> emptyPage = Page.empty();
+		doReturn(emptyPage).when(archiveFileRepository)
+		                   .findAll(any(Specification.class), any(org.springframework.data.domain.Pageable.class));
+		doReturn(emptyPage).when(audioFileRepository)
+		                   .findAll(any(Specification.class), any(org.springframework.data.domain.Pageable.class));
+		doReturn(emptyPage).when(binaryFileRepository)
+		                   .findAll(any(Specification.class), any(org.springframework.data.domain.Pageable.class));
+		doReturn(emptyPage).when(dataFileRepository)
+		                   .findAll(any(Specification.class), any(org.springframework.data.domain.Pageable.class));
+		doReturn(emptyPage).when(documentFileRepository)
+		                   .findAll(any(Specification.class), any(org.springframework.data.domain.Pageable.class));
+		doReturn(emptyPage).when(executableFileRepository)
+		                   .findAll(any(Specification.class), any(org.springframework.data.domain.Pageable.class));
+		doReturn(emptyPage).when(fontFileRepository)
+		                   .findAll(any(Specification.class), any(org.springframework.data.domain.Pageable.class));
+		doReturn(emptyPage).when(iconFileRepository)
+		                   .findAll(any(Specification.class), any(org.springframework.data.domain.Pageable.class));
+		doReturn(emptyPage).when(imageFileRepository)
+		                   .findAll(any(Specification.class), any(org.springframework.data.domain.Pageable.class));
+		doReturn(emptyPage).when(interactiveFileRepository)
+		                   .findAll(any(Specification.class), any(org.springframework.data.domain.Pageable.class));
+		doReturn(emptyPage).when(thumbFileRepository)
+		                   .findAll(any(Specification.class), any(org.springframework.data.domain.Pageable.class));
+		doReturn(emptyPage).when(vectorFileRepository)
+		                   .findAll(any(Specification.class), any(org.springframework.data.domain.Pageable.class));
+		doReturn(emptyPage).when(videoFileRepository)
+		                   .findAll(any(Specification.class), any(org.springframework.data.domain.Pageable.class));
+
+		assertThat(new ArchiveFileService(archiveFileRepository).findAll(pagedRequest)).isNotNull();
+		assertThat(new AudioFileService(audioFileRepository).findAll(pagedRequest)).isNotNull();
+		assertThat(new BinaryFileService(binaryFileRepository).findAll(pagedRequest)).isNotNull();
+		assertThat(new DataFileService(dataFileRepository).findAll(pagedRequest)).isNotNull();
+		assertThat(new DocumentFileService(documentFileRepository).findAll(pagedRequest)).isNotNull();
+		assertThat(new ExecutableFileService(executableFileRepository).findAll(pagedRequest)).isNotNull();
+		assertThat(new FontFileService(fontFileRepository).findAll(pagedRequest)).isNotNull();
+		assertThat(new IconFileService(iconFileRepository).findAll(pagedRequest)).isNotNull();
+		assertThat(new ImageFileService(imageFileRepository).findAll(pagedRequest)).isNotNull();
+		assertThat(new InteractiveFileService(interactiveFileRepository).findAll(pagedRequest)).isNotNull();
+		assertThat(new ThumbFileService(thumbFileRepository).findAll(pagedRequest)).isNotNull();
+		assertThat(new VectorFileService(vectorFileRepository).findAll(pagedRequest)).isNotNull();
+		assertThat(new VideoFileService(videoFileRepository).findAll(pagedRequest)).isNotNull();
+	}
+
+	@Test
+	void findById_returnsResponse_whenEntityExists_forAllFileTypeServices() {
+		var archive     = org.mockito.Mockito.mock(fi.poltsi.vempain.file.entity.ArchiveFileEntity.class);
+		var audio       = org.mockito.Mockito.mock(fi.poltsi.vempain.file.entity.AudioFileEntity.class);
+		var binary      = org.mockito.Mockito.mock(fi.poltsi.vempain.file.entity.BinaryFileEntity.class);
+		var data        = org.mockito.Mockito.mock(fi.poltsi.vempain.file.entity.DataFileEntity.class);
+		var document    = org.mockito.Mockito.mock(fi.poltsi.vempain.file.entity.DocumentFileEntity.class);
+		var executable  = org.mockito.Mockito.mock(fi.poltsi.vempain.file.entity.ExecutableFileEntity.class);
+		var font        = org.mockito.Mockito.mock(fi.poltsi.vempain.file.entity.FontFileEntity.class);
+		var icon        = org.mockito.Mockito.mock(fi.poltsi.vempain.file.entity.IconFileEntity.class);
+		var image       = org.mockito.Mockito.mock(fi.poltsi.vempain.file.entity.ImageFileEntity.class);
+		var interactive = org.mockito.Mockito.mock(fi.poltsi.vempain.file.entity.InteractiveFileEntity.class);
+		var thumb       = org.mockito.Mockito.mock(fi.poltsi.vempain.file.entity.ThumbFileEntity.class);
+		var vector      = org.mockito.Mockito.mock(fi.poltsi.vempain.file.entity.VectorFileEntity.class);
+		var video       = org.mockito.Mockito.mock(fi.poltsi.vempain.file.entity.VideoFileEntity.class);
+
+		when(archive.toResponse()).thenReturn(new fi.poltsi.vempain.file.api.response.files.ArchiveFileResponse());
+		when(audio.toResponse()).thenReturn(new fi.poltsi.vempain.file.api.response.files.AudioFileResponse());
+		when(binary.toResponse()).thenReturn(new fi.poltsi.vempain.file.api.response.files.BinaryFileResponse());
+		when(data.toResponse()).thenReturn(new fi.poltsi.vempain.file.api.response.files.DataFileResponse());
+		when(document.toResponse()).thenReturn(new fi.poltsi.vempain.file.api.response.files.DocumentFileResponse());
+		when(executable.toResponse()).thenReturn(new fi.poltsi.vempain.file.api.response.files.ExecutableFileResponse());
+		when(font.toResponse()).thenReturn(new fi.poltsi.vempain.file.api.response.files.FontFileResponse());
+		when(icon.toResponse()).thenReturn(new fi.poltsi.vempain.file.api.response.files.IconFileResponse());
+		when(image.toResponse()).thenReturn(new fi.poltsi.vempain.file.api.response.files.ImageFileResponse());
+		when(interactive.toResponse()).thenReturn(new fi.poltsi.vempain.file.api.response.files.InteractiveFileResponse());
+		when(thumb.toResponse()).thenReturn(new fi.poltsi.vempain.file.api.response.files.ThumbFileResponse());
+		when(vector.toResponse()).thenReturn(new fi.poltsi.vempain.file.api.response.files.VectorFileResponse());
+		when(video.toResponse()).thenReturn(new fi.poltsi.vempain.file.api.response.files.VideoFileResponse());
+
+		when(archiveFileRepository.findById(2L)).thenReturn(Optional.of(archive));
+		when(audioFileRepository.findById(2L)).thenReturn(Optional.of(audio));
+		when(binaryFileRepository.findById(2L)).thenReturn(Optional.of(binary));
+		when(dataFileRepository.findById(2L)).thenReturn(Optional.of(data));
+		when(documentFileRepository.findById(2L)).thenReturn(Optional.of(document));
+		when(executableFileRepository.findById(2L)).thenReturn(Optional.of(executable));
+		when(fontFileRepository.findById(2L)).thenReturn(Optional.of(font));
+		when(iconFileRepository.findById(2L)).thenReturn(Optional.of(icon));
+		when(imageFileRepository.findById(2L)).thenReturn(Optional.of(image));
+		when(interactiveFileRepository.findById(2L)).thenReturn(Optional.of(interactive));
+		when(thumbFileRepository.findById(2L)).thenReturn(Optional.of(thumb));
+		when(vectorFileRepository.findById(2L)).thenReturn(Optional.of(vector));
+		when(videoFileRepository.findById(2L)).thenReturn(Optional.of(video));
+
+		assertThat(new ArchiveFileService(archiveFileRepository).findById(2L)).isNotNull();
+		assertThat(new AudioFileService(audioFileRepository).findById(2L)).isNotNull();
+		assertThat(new BinaryFileService(binaryFileRepository).findById(2L)).isNotNull();
+		assertThat(new DataFileService(dataFileRepository).findById(2L)).isNotNull();
+		assertThat(new DocumentFileService(documentFileRepository).findById(2L)).isNotNull();
+		assertThat(new ExecutableFileService(executableFileRepository).findById(2L)).isNotNull();
+		assertThat(new FontFileService(fontFileRepository).findById(2L)).isNotNull();
+		assertThat(new IconFileService(iconFileRepository).findById(2L)).isNotNull();
+		assertThat(new ImageFileService(imageFileRepository).findById(2L)).isNotNull();
+		assertThat(new InteractiveFileService(interactiveFileRepository).findById(2L)).isNotNull();
+		assertThat(new ThumbFileService(thumbFileRepository).findById(2L)).isNotNull();
+		assertThat(new VectorFileService(vectorFileRepository).findById(2L)).isNotNull();
+		assertThat(new VideoFileService(videoFileRepository).findById(2L)).isNotNull();
+	}
+
+	@Test
+	void delete_returnsExpectedStatus_forAllFileTypeServices() {
+		var archiveService     = new ArchiveFileService(archiveFileRepository);
+		var audioService       = new AudioFileService(audioFileRepository);
+		var binaryService      = new BinaryFileService(binaryFileRepository);
+		var dataService        = new DataFileService(dataFileRepository);
+		var documentService    = new DocumentFileService(documentFileRepository);
+		var executableService  = new ExecutableFileService(executableFileRepository);
+		var fontService        = new FontFileService(fontFileRepository);
+		var iconService        = new IconFileService(iconFileRepository);
+		var imageService       = new ImageFileService(imageFileRepository);
+		var interactiveService = new InteractiveFileService(interactiveFileRepository);
+		var thumbService       = new ThumbFileService(thumbFileRepository);
+		var vectorService      = new VectorFileService(vectorFileRepository);
+		var videoService       = new VideoFileService(videoFileRepository);
+
+		when(archiveFileRepository.existsById(1L)).thenReturn(true);
+		when(audioFileRepository.existsById(1L)).thenReturn(true);
+		when(binaryFileRepository.existsById(1L)).thenReturn(true);
+		when(dataFileRepository.existsById(1L)).thenReturn(true);
+		when(documentFileRepository.existsById(1L)).thenReturn(true);
+		when(executableFileRepository.existsById(1L)).thenReturn(true);
+		when(fontFileRepository.existsById(1L)).thenReturn(true);
+		when(iconFileRepository.existsById(1L)).thenReturn(true);
+		when(imageFileRepository.existsById(1L)).thenReturn(true);
+		when(interactiveFileRepository.existsById(1L)).thenReturn(true);
+		when(thumbFileRepository.existsById(1L)).thenReturn(true);
+		when(vectorFileRepository.existsById(1L)).thenReturn(true);
+		when(videoFileRepository.existsById(1L)).thenReturn(true);
+
+		assertThat(archiveService.delete(1L)).isEqualTo(HttpStatus.OK);
+		assertThat(audioService.delete(1L)).isEqualTo(HttpStatus.OK);
+		assertThat(binaryService.delete(1L)).isEqualTo(HttpStatus.OK);
+		assertThat(dataService.delete(1L)).isEqualTo(HttpStatus.OK);
+		assertThat(documentService.delete(1L)).isEqualTo(HttpStatus.OK);
+		assertThat(executableService.delete(1L)).isEqualTo(HttpStatus.OK);
+		assertThat(fontService.delete(1L)).isEqualTo(HttpStatus.OK);
+		assertThat(iconService.delete(1L)).isEqualTo(HttpStatus.OK);
+		assertThat(imageService.delete(1L)).isEqualTo(HttpStatus.OK);
+		assertThat(interactiveService.delete(1L)).isEqualTo(HttpStatus.OK);
+		assertThat(thumbService.delete(1L)).isEqualTo(HttpStatus.OK);
+		assertThat(vectorService.delete(1L)).isEqualTo(HttpStatus.OK);
+		assertThat(videoService.delete(1L)).isEqualTo(HttpStatus.OK);
+
+		when(archiveFileRepository.existsById(9L)).thenReturn(false);
+		when(audioFileRepository.existsById(9L)).thenReturn(false);
+		when(binaryFileRepository.existsById(9L)).thenReturn(false);
+		when(dataFileRepository.existsById(9L)).thenReturn(false);
+		when(documentFileRepository.existsById(9L)).thenReturn(false);
+		when(executableFileRepository.existsById(9L)).thenReturn(false);
+		when(fontFileRepository.existsById(9L)).thenReturn(false);
+		when(iconFileRepository.existsById(9L)).thenReturn(false);
+		when(imageFileRepository.existsById(9L)).thenReturn(false);
+		when(interactiveFileRepository.existsById(9L)).thenReturn(false);
+		when(thumbFileRepository.existsById(9L)).thenReturn(false);
+		when(vectorFileRepository.existsById(9L)).thenReturn(false);
+		when(videoFileRepository.existsById(9L)).thenReturn(false);
+
+		assertThat(archiveService.delete(9L)).isEqualTo(HttpStatus.NOT_FOUND);
+		assertThat(audioService.delete(9L)).isEqualTo(HttpStatus.NOT_FOUND);
+		assertThat(binaryService.delete(9L)).isEqualTo(HttpStatus.NOT_FOUND);
+		assertThat(dataService.delete(9L)).isEqualTo(HttpStatus.NOT_FOUND);
+		assertThat(documentService.delete(9L)).isEqualTo(HttpStatus.NOT_FOUND);
+		assertThat(executableService.delete(9L)).isEqualTo(HttpStatus.NOT_FOUND);
+		assertThat(fontService.delete(9L)).isEqualTo(HttpStatus.NOT_FOUND);
+		assertThat(iconService.delete(9L)).isEqualTo(HttpStatus.NOT_FOUND);
+		assertThat(imageService.delete(9L)).isEqualTo(HttpStatus.NOT_FOUND);
+		assertThat(interactiveService.delete(9L)).isEqualTo(HttpStatus.NOT_FOUND);
+		assertThat(thumbService.delete(9L)).isEqualTo(HttpStatus.NOT_FOUND);
+		assertThat(vectorService.delete(9L)).isEqualTo(HttpStatus.NOT_FOUND);
+		assertThat(videoService.delete(9L)).isEqualTo(HttpStatus.NOT_FOUND);
+	}
+}

--- a/service/src/test/java/fi/poltsi/vempain/file/service/files/FileTypeServicesUTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/service/files/FileTypeServicesUTC.java
@@ -94,6 +94,7 @@ class FileTypeServicesUTC {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	void findAll_returnsPagedResponse_forAllFileTypeServices() {
 		var pagedRequest = new PagedRequest();
 		pagedRequest.setPage(0);


### PR DESCRIPTION
This pull request updates the file API endpoints to use a more flexible and consistent paging/search pattern, and improves documentation for the file backend agent. The main changes are the switch from GET to POST for paginated file listing endpoints (now accepting a `PagedRequest` body), updated validation constraints, and the addition of a comprehensive agent guide.

**API Endpoint Modernization:**

* All file-type API interfaces (`ArchiveFileAPI`, `AudioFileAPI`, `BinaryFileAPI`, `DataFileAPI`, `DocumentFileAPI`, `ExecutableFileAPI`) now use `POST <BASE_PATH>/paged` with a `@Valid @RequestBody PagedRequest` for paged listing, replacing the previous GET endpoints with query parameters. This enables support for more complex search and sorting. [[1]](diffhunk://#diff-65420b3a259cff448ee0ed0462c6081eb7af995bdb73ed6f86f39d03acfe324dL11-R34) [[2]](diffhunk://#diff-641cb4ec2935ca69a05163cf95ad2f552ecb6ee1f60a9ba208eb96f69111a5f1L11-R34) [[3]](diffhunk://#diff-8604cfbc7874a78c4a8e0dedb7a9c17d87cf4cf242a61bb60d99d4cc5c3769aeL11-R34) [[4]](diffhunk://#diff-2159ce2f397e3221c13295bbce82749d3960cff74520d831bb86943282c8c701R3-R32) [[5]](diffhunk://#diff-3f9ffb58c4c0d7dc875823793495b3672dfdc12b705be478663dc5b402d1f377L11-R34) [[6]](diffhunk://#diff-8a57caa1cc5df194662f5c0893be1e81693370b4884ec6ff4d7260c64b8eb3b0R3-R32)
* The OpenAPI documentation for these endpoints is updated to reflect the new POST pattern, including improved descriptions and response codes (400 for invalid requests). [[1]](diffhunk://#diff-65420b3a259cff448ee0ed0462c6081eb7af995bdb73ed6f86f39d03acfe324dL11-R34) [[2]](diffhunk://#diff-641cb4ec2935ca69a05163cf95ad2f552ecb6ee1f60a9ba208eb96f69111a5f1L11-R34) [[3]](diffhunk://#diff-8604cfbc7874a78c4a8e0dedb7a9c17d87cf4cf242a61bb60d99d4cc5c3769aeL11-R34) [[4]](diffhunk://#diff-2159ce2f397e3221c13295bbce82749d3960cff74520d831bb86943282c8c701R3-R32) [[5]](diffhunk://#diff-3f9ffb58c4c0d7dc875823793495b3672dfdc12b705be478663dc5b402d1f377L11-R34) [[6]](diffhunk://#diff-8a57caa1cc5df194662f5c0893be1e81693370b4884ec6ff4d7260c64b8eb3b0R3-R32)

**Validation Adjustments:**

* The minimum allowed string length for relevant fields in `ScanRequest` is reduced from 2 to 1 character, allowing single-character directory names. [[1]](diffhunk://#diff-3f894298cf4ac4c4fb93f4dabe9f230d5e328cdd6e2ea30f8b2dbaf41b732bd1L24-R24) [[2]](diffhunk://#diff-3f894298cf4ac4c4fb93f4dabe9f230d5e328cdd6e2ea30f8b2dbaf41b732bd1L36-R36)

**Documentation Improvements:**

* A new agent guide (`AGENTS.md`) is added, detailing the architecture, file-type hierarchy, paged list pattern, conventions, and instructions for extending the backend with new file types.

These changes improve the flexibility, consistency, and maintainability of the file backend APIs and provide clearer guidance for contributors.