### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/service/src/main/java/fi/poltsi/vempain/file/service/PathCompletionService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/PathCompletionService.java
@@ -40,8 +40,17 @@ public class PathCompletionService {
 								   .equals(ORIGINAL) ? originalRootDirectory : exportedRootDirectory;
 
 		try {
-			// Determine the working directory by joining the configured root with the request path.
-			var fullPath = Paths.get(rootDirectory, requestPath);
+			var rootPath = Paths.get(rootDirectory)
+								.normalize()
+								.toAbsolutePath();
+			var sanitizedRequestPath = requestPath.replaceFirst("^[\\\\/]+", "");
+			// Resolve user path against root and ensure it cannot escape the configured root directory.
+			var fullPath = rootPath.resolve(sanitizedRequestPath)
+							   .normalize();
+			if (!fullPath.startsWith(rootPath)) {
+				log.warn("Rejected path completion request outside configured root: {}", requestPath);
+				return new PathCompletionResponse(completions);
+			}
 
 			if (Files.exists(fullPath) && Files.isDirectory(fullPath)) {
 				// If an exact directory exists, list its immediate subdirectories.
@@ -66,7 +75,7 @@ public class PathCompletionService {
 			} else {
 				// Else, perform prefix matching in the parent directory.
 				var parentPath = fullPath.getParent();
-				if (parentPath != null && Files.exists(parentPath)) {
+				if (parentPath != null && parentPath.startsWith(rootPath) && Files.exists(parentPath)) {
 					var prefix = fullPath.getFileName()
 										 .toString();
 					try (DirectoryStream<Path> stream = Files.newDirectoryStream(parentPath)) {


### PR DESCRIPTION
Potential fix for [https://github.com/Vempain/vempain-file-backend/security/code-scanning/2](https://github.com/Vempain/vempain-file-backend/security/code-scanning/2)

To fix this safely without changing intended functionality, resolve the user-provided path against a normalized absolute root directory, normalize the result, and **reject/short-circuit** if the resolved path is outside that root. Apply the same containment rule to `parentPath` before scanning it. This preserves path completion behavior for valid in-root paths while preventing traversal or absolute-path escape.

Best concrete fix in `service/src/main/java/fi/poltsi/vempain/file/service/PathCompletionService.java`:
1. Build `rootPath = Paths.get(rootDirectory).normalize().toAbsolutePath();`
2. Normalize incoming request path and strip leading `/` or `\` so it is always treated as relative when resolving.
3. Resolve with `rootPath.resolve(sanitizedRequestPath).normalize();`
4. If resolved `fullPath` does not start with `rootPath`, return empty completion response.
5. Before using `parentPath`, ensure it is also under `rootPath` with `parentPath.startsWith(rootPath)`.

No controller change is required for the core fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
