### PR TITLE
Use admin data api

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,10 @@ For complex native-SQL search (e.g. across joined tables), follow `FileGroupRepo
 - `FileGroupRepositoryImpl` uses raw native SQL — keep column names in sync with Flyway scripts
 - Background refresh of modified source files runs via `UpdatedFileRefreshSchedulerService` (`vempain.refresh-updated-files.*`)
 - Refresh checkpoints are persisted in `scheduler_checkpoint`; per-file admin publication knowledge is stored in `files.site_file_published`
+- GPS dataset publication has two flows now:
+    - `POST /api/data-publish/gps-timeseries/{directoryPath}` builds a canonical `gps_timeseries_<path>` identifier from the directory path.
+    - `POST /api/data-publish/gps-timeseries` accepts `file_group_id` + `time_series_name`, normalizes the requested name to Admin-safe snake_case, and
+      publishes that dataset for the selected file group.
 
 ## Further Reading
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ For complex native-SQL search (e.g. across joined tables), follow `FileGroupRepo
 
 - JSON field names use snake_case (`@JsonNaming(SnakeCaseStrategy.class)` in DTOs)
 - Test class suffix `ITC` = integration test, `UTC` = unit test
+- After every code modification, run relevant tests for touched modules and report the results in the response
 - Schema managed by Flyway; migrations under `service/src/main/resources/db/migration/`
 - `FileGroupRepositoryImpl` uses raw native SQL — keep column names in sync with Flyway scripts
 - Background refresh of modified source files runs via `UpdatedFileRefreshSchedulerService` (`vempain.refresh-updated-files.*`)

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 	api "org.springframework.boot:spring-boot-starter-validation:${springBootVersion}"
 	// This needs to be built first in vempain-auth
 	api "fi.poltsi.vempain:vempain-auth-api:${vempainAuthVersion}"
+	api "fi.poltsi.vempain:vempain-admin-backend-api:${vempainAdminVersion}"
 	implementation "io.swagger.core.v3:swagger-annotations:${swaggerVersion}"
 	testImplementation "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
 	testImplementation "org.junit.jupiter:junit-jupiter:${junitVersion}"

--- a/api/src/main/java/fi/poltsi/vempain/file/api/FileTypeEnum.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/api/FileTypeEnum.java
@@ -13,6 +13,7 @@ public enum FileTypeEnum {
 	ARCHIVE("(Un)Compressed archive files", "archive"),
 	AUDIO("Audio files", "audio"),
 	BINARY("Binary file", "binary"),
+	MUSIC("Music files with artist/album/track metadata", "music"),
 	DATA("Various data files, binary or ascii", "data"),
 	DOCUMENT("Document files", "document"),
 	EXECUTABLE("Executable files including scripts", "executable"),

--- a/api/src/main/java/fi/poltsi/vempain/file/api/request/CreateGpsTimeSeriesRequest.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/api/request/CreateGpsTimeSeriesRequest.java
@@ -1,0 +1,29 @@
+package fi.poltsi.vempain.file.api.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.annotation.JsonNaming;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Schema(name = "CreateGpsTimeSeriesRequest", description = "Request to create a GPS time-series dataset from a file group")
+public class CreateGpsTimeSeriesRequest {
+
+	@Schema(description = "ID of the file group containing GPS-tagged images", example = "42", required = true)
+	@NotNull(message = "File group ID must not be null")
+	private Long fileGroupId;
+
+	@Schema(description = "Name of the time-series dataset (identifier)", example = "holidays_2024", required = true)
+	@NotBlank(message = "Time series name must not be blank")
+	private String timeSeriesName;
+}
+

--- a/api/src/main/java/fi/poltsi/vempain/file/api/response/files/MusicFileResponse.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/api/response/files/MusicFileResponse.java
@@ -18,14 +18,23 @@ public class MusicFileResponse extends AudioFileResponse {
 	@Schema(description = "Recording artist or band", example = "The Beatles")
 	private String artist;
 
+	@Schema(description = "Album artist, useful for compilations", example = "Various Artists")
+	private String albumArtist;
+
 	@Schema(description = "Album name", example = "Abbey Road")
 	private String album;
+
+	@Schema(description = "Release year", example = "1969")
+	private Integer year;
 
 	@Schema(description = "Track title", example = "Come Together")
 	private String trackName;
 
 	@Schema(description = "Track number within the album", example = "1")
 	private Integer trackNumber;
+
+	@Schema(description = "Total number of tracks on the album", example = "17")
+	private Integer trackTotal;
 
 	@Schema(description = "Music genre", example = "Rock")
 	private String genre;

--- a/api/src/main/java/fi/poltsi/vempain/file/api/response/files/MusicFileResponse.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/api/response/files/MusicFileResponse.java
@@ -1,0 +1,32 @@
+package fi.poltsi.vempain.file.api.response.files;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Response DTO representing a music file with artist/album metadata")
+public class MusicFileResponse extends AudioFileResponse {
+
+	@Schema(description = "Recording artist or band", example = "The Beatles")
+	private String artist;
+
+	@Schema(description = "Album name", example = "Abbey Road")
+	private String album;
+
+	@Schema(description = "Track title", example = "Come Together")
+	private String trackName;
+
+	@Schema(description = "Track number within the album", example = "1")
+	private Integer trackNumber;
+
+	@Schema(description = "Music genre", example = "Rock")
+	private String genre;
+}

--- a/api/src/main/java/fi/poltsi/vempain/file/rest/DataPublishAPI.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/rest/DataPublishAPI.java
@@ -1,18 +1,19 @@
 package fi.poltsi.vempain.file.rest;
 
 import fi.poltsi.vempain.admin.api.response.DataResponse;
+import fi.poltsi.vempain.file.api.request.CreateGpsTimeSeriesRequest;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Data publish API", description = "API for generating and publishing CSV datasets to Vempain Admin")
 public interface DataPublishAPI {
@@ -32,25 +33,24 @@ public interface DataPublishAPI {
 			@ApiResponse(responseCode = "401", description = "Unauthorized access", content = @Content)
 	})
 	@SecurityRequirement(name = "Bearer Authentication")
-	@GetMapping(path = BASE_PATH + "/music", produces = MediaType.APPLICATION_JSON_VALUE)
+	@PostMapping(path = BASE_PATH + "/music", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<DataResponse> publishMusicDataset();
 
 	@Operation(
-			summary = "Generate and publish GPS time-series dataset for a directory",
-			description = "Generates a CSV time-series dataset from images with GPS metadata in the specified directory path and publishes it to Vempain Admin",
+			summary = "Generate and publish GPS time-series dataset from a file group",
+			description = "Generates a CSV time-series dataset from images with GPS metadata in the specified file group and publishes it to Vempain Admin",
 			tags = "Data publish API"
 	)
-	@Parameter(name = "directoryPath", description = "URL-encoded relative directory path to scan for GPS-tagged images", example = "holidays_2024", required = true)
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "GPS time-series dataset published successfully",
 						 content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
 											schema = @Schema(implementation = DataResponse.class))),
-			@ApiResponse(responseCode = "400", description = "Invalid directory path", content = @Content),
-			@ApiResponse(responseCode = "404", description = "No GPS-tagged images found in directory", content = @Content),
+			@ApiResponse(responseCode = "400", description = "Invalid request parameters", content = @Content),
+			@ApiResponse(responseCode = "404", description = "No GPS-tagged images found in file group", content = @Content),
 			@ApiResponse(responseCode = "500", description = "Internal server error", content = @Content),
 			@ApiResponse(responseCode = "401", description = "Unauthorized access", content = @Content)
 	})
 	@SecurityRequirement(name = "Bearer Authentication")
-	@GetMapping(path = BASE_PATH + "/gps-timeseries/{directoryPath}", produces = MediaType.APPLICATION_JSON_VALUE)
-	ResponseEntity<DataResponse> publishGpsTimeSeries(@PathVariable("directoryPath") String directoryPath);
+	@PostMapping(path = BASE_PATH + "/gps-timeseries", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<DataResponse> publishGpsTimeSeries(@Valid @RequestBody CreateGpsTimeSeriesRequest request);
 }

--- a/api/src/main/java/fi/poltsi/vempain/file/rest/DataPublishAPI.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/rest/DataPublishAPI.java
@@ -11,8 +11,8 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 
 @Tag(name = "Data publish API", description = "API for generating and publishing CSV datasets to Vempain Admin")
 public interface DataPublishAPI {
@@ -32,7 +32,7 @@ public interface DataPublishAPI {
 			@ApiResponse(responseCode = "401", description = "Unauthorized access", content = @Content)
 	})
 	@SecurityRequirement(name = "Bearer Authentication")
-	@PostMapping(path = BASE_PATH + "/music", produces = MediaType.APPLICATION_JSON_VALUE)
+	@GetMapping(path = BASE_PATH + "/music", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<DataResponse> publishMusicDataset();
 
 	@Operation(
@@ -51,6 +51,6 @@ public interface DataPublishAPI {
 			@ApiResponse(responseCode = "401", description = "Unauthorized access", content = @Content)
 	})
 	@SecurityRequirement(name = "Bearer Authentication")
-	@PostMapping(path = BASE_PATH + "/gps-timeseries/{directoryPath}", produces = MediaType.APPLICATION_JSON_VALUE)
+	@GetMapping(path = BASE_PATH + "/gps-timeseries/{directoryPath}", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<DataResponse> publishGpsTimeSeries(@PathVariable("directoryPath") String directoryPath);
 }

--- a/api/src/main/java/fi/poltsi/vempain/file/rest/files/MusicFileAPI.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/rest/files/MusicFileAPI.java
@@ -1,0 +1,59 @@
+package fi.poltsi.vempain.file.rest.files;
+
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
+import fi.poltsi.vempain.auth.api.response.PagedResponse;
+import fi.poltsi.vempain.file.api.response.files.MusicFileResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Music file API", description = "API for accessing and managing music files with artist/album metadata")
+public interface MusicFileAPI {
+	String BASE_PATH = "/files/music";
+
+	@Operation(summary = "Get all music files", description = "Retrieve music files with paging, sorting and search", tags = "Music file API")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Page of music files retrieved successfully"),
+			@ApiResponse(responseCode = "400", description = "Invalid request"),
+			@ApiResponse(responseCode = "403", description = "Unauthorized access"),
+			@ApiResponse(responseCode = "500", description = "Internal server error")
+	})
+	@SecurityRequirement(name = "Bearer Authentication")
+	@PostMapping(path = BASE_PATH + "/paged", produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<PagedResponse<MusicFileResponse>> findAll(@Valid @RequestBody PagedRequest pagedRequest);
+
+	@Operation(summary = "Get music file by ID", description = "Retrieve specific music file by its unique identifier", tags = "Music file API")
+	@Parameter(name = "id", description = "Music file ID to be fetched", example = "1")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Specific music file retrieved successfully"),
+			@ApiResponse(responseCode = "403", description = "Unauthorized access"),
+			@ApiResponse(responseCode = "404", description = "Specific music file not found"),
+			@ApiResponse(responseCode = "500", description = "Internal server error")
+	})
+	@SecurityRequirement(name = "Bearer Authentication")
+	@GetMapping(path = BASE_PATH + "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<MusicFileResponse> findById(@PathVariable("id") long id);
+
+	@Operation(summary = "Remove music file by ID", description = "Remove specific music file by its unique identifier", tags = "Music file API")
+	@Parameter(name = "id", description = "Music file ID to be removed", example = "1")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Specific music file removed successfully"),
+			@ApiResponse(responseCode = "403", description = "Unauthorized access"),
+			@ApiResponse(responseCode = "404", description = "Specific music file not found"),
+			@ApiResponse(responseCode = "500", description = "Internal server error")
+	})
+	@SecurityRequirement(name = "Bearer Authentication")
+	@DeleteMapping(BASE_PATH + "/{id}")
+	ResponseEntity<Void> delete(@PathVariable("id") long id);
+}

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -65,3 +65,59 @@
 - The database schema is Flyway-managed; if you change entities or repository SQL, update `service/src/main/resources/db/migration/**` and the native SQL in
   `FileGroupRepositoryImpl` together.
 
+## Music files and CSV dataset generation
+
+### MusicFileEntity
+
+Music files are a specialised subtype of `AudioFileEntity`. When `DirectoryProcessorService` processes an audio MIME-type file it probes the metadata via
+`MetadataTool.hasMusicMetadata()` (checks for ID3/Vorbis artist, title, or album tags) and, if music metadata is present, stores the file as a
+`MusicFileEntity` (type `MUSIC`) instead of a plain `AudioFileEntity` (type `AUDIO`).
+
+Extra fields persisted in `music_files` (3-level JOINED inheritance: `files` → `audio_files` → `music_files`):
+`artist`, `album`, `track_name`, `track_number`, `genre`.
+
+Flyway migration: `V1002__music_files.sql`.
+
+### DataService and DataPublishAPI
+
+`DataService` generates CSV datasets on-demand and publishes them to Vempain Admin via `VempainAdminDataClient`
+(a Feign client extending `fi.poltsi.vempain.admin.rest.DataAPI`).
+
+Datasets are **ephemeral** — never stored in the file database. They are built at call time and sent straight to Admin.
+
+Two dataset types are supported:
+
+| Dataset | Endpoint | Identifier | CSV columns |
+|---------|----------|------------|-------------|
+| Music library | `POST /api/data-publish/music` | `music_library` | `artist, album, track_number, track_name, genre, duration_seconds` |
+| GPS time-series | `POST /api/data-publish/gps-timeseries/{directoryPath}` | `gps_timeseries_<path>` | `timestamp, latitude, latitude_ref, longitude, longitude_ref, altitude, filename` |
+
+#### Music dataset example
+
+```
+POST /api/data-publish/music
+```
+
+Reads all `MusicFileEntity` rows ordered by artist → album → track\_number, builds the CSV, and calls
+`DataAPI.createDataSet` / `updateDataSet` + `publishDataSet` on Vempain Admin.
+
+#### GPS time-series example
+
+```
+POST /api/data-publish/gps-timeseries/holidays_2024
+```
+
+Reads all `ImageFileEntity` rows whose `file_path` matches `/holidays/2024` and that have a non-null
+`gps_location`, ordered by GPS timestamp (falls back to original-datetime). The resulting CSV is
+published to Admin under identifier `gps_timeseries_holidays_2024`.
+
+The `directoryPath` parameter in the URL is the path segment **after** the leading slash. Slashes must
+not appear inside the segment (use underscores instead, or URL-encode). The service re-adds the leading
+`/` before querying the database.
+
+#### Create-or-update logic
+
+`DataService.createOrUpdate()` first attempts `PUT` (update). If the Admin service responds with 404 it
+falls back to `POST` (create). After a successful create/update it always calls the `publish` endpoint.
+
+

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -87,10 +87,11 @@ Datasets are **ephemeral** — never stored in the file database. They are built
 
 Two dataset types are supported:
 
-| Dataset | Endpoint | Identifier | CSV columns |
-|---------|----------|------------|-------------|
-| Music library | `POST /api/data-publish/music` | `music_library` | `artist, album, track_number, track_name, genre, duration_seconds` |
-| GPS time-series | `POST /api/data-publish/gps-timeseries/{directoryPath}` | `gps_timeseries_<path>` | `timestamp, latitude, latitude_ref, longitude, longitude_ref, altitude, filename` |
+| Dataset                      | Endpoint                                                | Identifier                                                                 | CSV columns                                                                       |
+|------------------------------|---------------------------------------------------------|----------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
+| Music library                | `POST /api/data-publish/music`                          | `music_library`                                                            | `artist, album, track_number, track_name, genre, duration_seconds`                |
+| GPS time-series              | `POST /api/data-publish/gps-timeseries/{directoryPath}` | `gps_timeseries_<path>`                                                    | `timestamp, latitude, latitude_ref, longitude, longitude_ref, altitude, filename` |
+| GPS time-series (file group) | `POST /api/data-publish/gps-timeseries`                 | caller-provided `time_series_name`, normalized to an Admin-safe identifier | `timestamp, latitude, latitude_ref, longitude, longitude_ref, altitude, filename` |
 
 #### Music dataset example
 
@@ -114,6 +115,20 @@ published to Admin under identifier `gps_timeseries_holidays_2024`.
 The `directoryPath` parameter in the URL is the path segment **after** the leading slash. Slashes must
 not appear inside the segment (use underscores instead, or URL-encode). The service re-adds the leading
 `/` before querying the database.
+
+#### GPS time-series by file group example
+
+```json
+POST /api/data-publish/gps-timeseries
+{
+  "file_group_id": 473,
+  "time_series_name": "matkailu-etiopia-2016"
+}
+```
+
+This path uses `ImageFileRepository.findByFileGroupIdWithGpsOrderedByTime(...)` instead of the directory-path lookup.
+`time_series_name` is normalized to the Admin identifier rules (`[a-z][a-z0-9_]*`): separators become underscores,
+empty values are rejected, and names that would otherwise start with a digit are prefixed with `gps_timeseries_`.
 
 #### Create-or-update logic
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,12 +15,12 @@ jjwtVersion=0.13.0
 # https://mvnrepository.com/artifact/org.junit/junit-bom
 junitVersion=6.0.3
 # https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-annotations
-swaggerVersion=2.2.45
+swaggerVersion=2.2.48
 # https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui
-springdocVersion=3.0.2
+springdocVersion=3.0.3
 # https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter
 mockitoVersion=5.23.0
 # https://github.com/Vempain/vempain-auth/packages/2723219
-vempainAuthVersion=1.0.6
+vempainAuthVersion=1.0.7
 # https://github.com/Vempain/vempain-admin-backend/packages/2624185
-vempainAdminVersion=1.0.13
+vempainAdminVersion=1.0.18

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,6 @@ springdocVersion=3.0.3
 # https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter
 mockitoVersion=5.23.0
 # https://github.com/Vempain/vempain-auth/packages/2723219
-vempainAuthVersion=1.0.7
+vempainAuthVersion=1.0.8
 # https://github.com/Vempain/vempain-admin-backend/packages/2624185
 vempainAdminVersion=1.0.18

--- a/service/src/main/java/fi/poltsi/vempain/file/controller/DataPublishController.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/controller/DataPublishController.java
@@ -1,0 +1,27 @@
+package fi.poltsi.vempain.file.controller;
+
+import fi.poltsi.vempain.admin.api.response.DataResponse;
+import fi.poltsi.vempain.file.rest.DataPublishAPI;
+import fi.poltsi.vempain.file.service.DataService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class DataPublishController implements DataPublishAPI {
+
+	private final DataService dataService;
+
+	@Override
+	public ResponseEntity<DataResponse> publishMusicDataset() {
+		var result = dataService.generateAndPublishMusicDataset();
+		return ResponseEntity.ok(result);
+	}
+
+	@Override
+	public ResponseEntity<DataResponse> publishGpsTimeSeries(String directoryPath) {
+		var result = dataService.generateAndPublishGpsTimeSeries(directoryPath);
+		return ResponseEntity.ok(result);
+	}
+}

--- a/service/src/main/java/fi/poltsi/vempain/file/controller/DataPublishController.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/controller/DataPublishController.java
@@ -1,6 +1,7 @@
 package fi.poltsi.vempain.file.controller;
 
 import fi.poltsi.vempain.admin.api.response.DataResponse;
+import fi.poltsi.vempain.file.api.request.CreateGpsTimeSeriesRequest;
 import fi.poltsi.vempain.file.rest.DataPublishAPI;
 import fi.poltsi.vempain.file.service.DataService;
 import lombok.RequiredArgsConstructor;
@@ -20,8 +21,8 @@ public class DataPublishController implements DataPublishAPI {
 	}
 
 	@Override
-	public ResponseEntity<DataResponse> publishGpsTimeSeries(String directoryPath) {
-		var result = dataService.generateAndPublishGpsTimeSeries(directoryPath);
+	public ResponseEntity<DataResponse> publishGpsTimeSeries(CreateGpsTimeSeriesRequest request) {
+		var result = dataService.generateAndPublishGpsTimeSeriesByFileGroup(request.getFileGroupId(), request.getTimeSeriesName());
 		return ResponseEntity.ok(result);
 	}
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/controller/files/MusicFileController.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/controller/files/MusicFileController.java
@@ -1,0 +1,40 @@
+package fi.poltsi.vempain.file.controller.files;
+
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
+import fi.poltsi.vempain.auth.api.response.PagedResponse;
+import fi.poltsi.vempain.file.api.response.files.MusicFileResponse;
+import fi.poltsi.vempain.file.rest.files.MusicFileAPI;
+import fi.poltsi.vempain.file.service.files.MusicFileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MusicFileController implements MusicFileAPI {
+
+	private final MusicFileService musicFileService;
+
+	@Override
+	public ResponseEntity<PagedResponse<MusicFileResponse>> findAll(PagedRequest pagedRequest) {
+		return ResponseEntity.ok(musicFileService.findAll(pagedRequest));
+	}
+
+	@Override
+	public ResponseEntity<MusicFileResponse> findById(long id) {
+		var response = musicFileService.findById(id);
+
+		if (response == null) {
+			return ResponseEntity.notFound()
+								 .build();
+		}
+
+		return ResponseEntity.ok(response);
+	}
+
+	@Override
+	public ResponseEntity<Void> delete(long id) {
+		return ResponseEntity.status(musicFileService.delete(id))
+							 .build();
+	}
+}

--- a/service/src/main/java/fi/poltsi/vempain/file/entity/AudioFileEntity.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/entity/AudioFileEntity.java
@@ -2,6 +2,7 @@ package fi.poltsi.vempain.file.entity;
 
 import fi.poltsi.vempain.file.api.response.files.AudioFileResponse;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
@@ -24,6 +25,7 @@ import java.time.Duration;
 public class AudioFileEntity extends FileEntity {
 
 	@Column(nullable = false, precision = 5)
+	@Convert(converter = DurationSecondsConverter.class)
 	private Duration duration;
 
 	@Column(name = "bit_rate", nullable = false)

--- a/service/src/main/java/fi/poltsi/vempain/file/entity/DurationSecondsConverter.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/entity/DurationSecondsConverter.java
@@ -1,0 +1,39 @@
+package fi.poltsi.vempain.file.entity;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+
+/**
+ * Persist Duration values as whole seconds (BigDecimal) to match NUMERIC(5,0) schema columns.
+ * Clamps to [0..99999] to prevent numeric overflow.
+ */
+@Converter
+public class DurationSecondsConverter implements AttributeConverter<Duration, BigDecimal> {
+
+	private static final long MAX_SECONDS = 99_999L;
+
+	@Override
+	public BigDecimal convertToDatabaseColumn(Duration attribute) {
+		if (attribute == null || attribute.isNegative()) {
+			return BigDecimal.ZERO;
+		}
+
+		var seconds = attribute.toSeconds();
+		if (seconds > MAX_SECONDS) {
+			seconds = MAX_SECONDS;
+		}
+
+		return BigDecimal.valueOf(seconds);
+	}
+
+	@Override
+	public Duration convertToEntityAttribute(BigDecimal dbData) {
+		if (dbData == null || dbData.signum() < 0) {
+			return Duration.ZERO;
+		}
+		return Duration.ofSeconds(dbData.longValue());
+	}
+}

--- a/service/src/main/java/fi/poltsi/vempain/file/entity/MusicFileEntity.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/entity/MusicFileEntity.java
@@ -31,14 +31,23 @@ public class MusicFileEntity extends AudioFileEntity {
 	@Column(name = "artist")
 	private String artist;
 
+	@Column(name = "album_artist")
+	private String albumArtist;
+
 	@Column(name = "album")
 	private String album;
+
+	@Column(name = "year")
+	private Integer year;
 
 	@Column(name = "track_name")
 	private String trackName;
 
 	@Column(name = "track_number")
 	private Integer trackNumber;
+
+	@Column(name = "track_total")
+	private Integer trackTotal;
 
 	@Column(name = "genre")
 	private String genre;
@@ -59,9 +68,12 @@ public class MusicFileEntity extends AudioFileEntity {
 
 		// Populate music-specific fields
 		response.setArtist(getArtist());
+		response.setAlbumArtist(getAlbumArtist());
 		response.setAlbum(getAlbum());
+		response.setYear(getYear());
 		response.setTrackName(getTrackName());
 		response.setTrackNumber(getTrackNumber());
+		response.setTrackTotal(getTrackTotal());
 		response.setGenre(getGenre());
 
 		return response;

--- a/service/src/main/java/fi/poltsi/vempain/file/entity/MusicFileEntity.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/entity/MusicFileEntity.java
@@ -1,0 +1,69 @@
+package fi.poltsi.vempain.file.entity;
+
+import fi.poltsi.vempain.file.api.response.files.MusicFileResponse;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * Entity representing a music file. Extends {@link AudioFileEntity} to inherit
+ * audio-technical fields (duration, bit rate, sample rate, codec, channels) and
+ * adds music-metadata fields (artist, album, track name, track number, genre).
+ */
+@SuperBuilder
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "music_files")
+@PrimaryKeyJoinColumn(name = "id")
+public class MusicFileEntity extends AudioFileEntity {
+
+	@Column(name = "artist")
+	private String artist;
+
+	@Column(name = "album")
+	private String album;
+
+	@Column(name = "track_name")
+	private String trackName;
+
+	@Column(name = "track_number")
+	private Integer trackNumber;
+
+	@Column(name = "genre")
+	private String genre;
+
+	@Override
+	public MusicFileResponse toResponse() {
+		MusicFileResponse response = new MusicFileResponse();
+
+		// Populate common file fields
+		populateBaseResponse(response);
+
+		// Populate audio-technical fields
+		response.setDuration(getDuration());
+		response.setBitRate(getBitRate());
+		response.setSampleRate(getSampleRate());
+		response.setCodec(getCodec());
+		response.setChannels(getChannels());
+
+		// Populate music-specific fields
+		response.setArtist(getArtist());
+		response.setAlbum(getAlbum());
+		response.setTrackName(getTrackName());
+		response.setTrackNumber(getTrackNumber());
+		response.setGenre(getGenre());
+
+		return response;
+	}
+}

--- a/service/src/main/java/fi/poltsi/vempain/file/entity/VideoFileEntity.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/entity/VideoFileEntity.java
@@ -2,6 +2,7 @@ package fi.poltsi.vempain.file.entity;
 
 import fi.poltsi.vempain.file.api.response.files.VideoFileResponse;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
@@ -33,6 +34,7 @@ public class VideoFileEntity extends FileEntity {
 	private double frameRate;
 
 	@Column(name = "duration", precision = 5, nullable = false)
+	@Convert(converter = DurationSecondsConverter.class)
 	private Duration duration;
 
 	@Column(name = "codec", nullable = false)

--- a/service/src/main/java/fi/poltsi/vempain/file/feign/VempainAdminDataClient.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/feign/VempainAdminDataClient.java
@@ -1,0 +1,8 @@
+package fi.poltsi.vempain.file.feign;
+
+import fi.poltsi.vempain.admin.rest.DataAPI;
+import org.springframework.cloud.openfeign.FeignClient;
+
+@FeignClient(name = "vempain-admin-data", url = "${vempain.service.admin-backend-url}")
+public interface VempainAdminDataClient extends DataAPI {
+}

--- a/service/src/main/java/fi/poltsi/vempain/file/repository/files/ImageFileRepository.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/repository/files/ImageFileRepository.java
@@ -18,4 +18,11 @@ public interface ImageFileRepository extends JpaRepository<ImageFileEntity, Long
 	 */
 	@Query("SELECT i FROM ImageFileEntity i WHERE i.filePath = :path AND i.gpsLocation IS NOT NULL ORDER BY COALESCE(i.gpsTimestamp, i.originalDatetime) ASC NULLS LAST")
 	List<ImageFileEntity> findByFilePathWithGpsOrderedByTime(@Param("path") String path);
+
+	/**
+	 * Find all image files in a given file group that have GPS location data,
+	 * ordered by their GPS timestamp (or original datetime as fallback).
+	 */
+	@Query("SELECT i FROM ImageFileEntity i JOIN i.fileGroups fg WHERE fg.id = :fileGroupId AND i.gpsLocation IS NOT NULL ORDER BY COALESCE(i.gpsTimestamp, i.originalDatetime) ASC NULLS LAST")
+	List<ImageFileEntity> findByFileGroupIdWithGpsOrderedByTime(@Param("fileGroupId") Long fileGroupId);
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/repository/files/ImageFileRepository.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/repository/files/ImageFileRepository.java
@@ -3,9 +3,19 @@ package fi.poltsi.vempain.file.repository.files;
 import fi.poltsi.vempain.file.entity.ImageFileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ImageFileRepository extends JpaRepository<ImageFileEntity, Long>, JpaSpecificationExecutor<ImageFileEntity> {
-	// Add custom query methods if necessary
+
+	/**
+	 * Find all image files in the given directory path that have GPS location data,
+	 * ordered by their GPS timestamp (or original datetime as fallback).
+	 */
+	@Query("SELECT i FROM ImageFileEntity i WHERE i.filePath = :path AND i.gpsLocation IS NOT NULL ORDER BY COALESCE(i.gpsTimestamp, i.originalDatetime) ASC NULLS LAST")
+	List<ImageFileEntity> findByFilePathWithGpsOrderedByTime(@Param("path") String path);
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/repository/files/MusicFileRepository.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/repository/files/MusicFileRepository.java
@@ -1,0 +1,14 @@
+package fi.poltsi.vempain.file.repository.files;
+
+import fi.poltsi.vempain.file.entity.MusicFileEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MusicFileRepository extends JpaRepository<MusicFileEntity, Long>, JpaSpecificationExecutor<MusicFileEntity> {
+
+	List<MusicFileEntity> findAllByOrderByArtistAscAlbumAscTrackNumberAsc();
+}

--- a/service/src/main/java/fi/poltsi/vempain/file/rest/DataPublishAPI.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/rest/DataPublishAPI.java
@@ -1,0 +1,56 @@
+package fi.poltsi.vempain.file.rest;
+
+import fi.poltsi.vempain.admin.api.response.DataResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Tag(name = "Data publish API", description = "API for generating and publishing CSV datasets to Vempain Admin")
+public interface DataPublishAPI {
+	String BASE_PATH = "/data-publish";
+
+	@Operation(
+			summary = "Generate and publish music dataset",
+			description = "Generates a CSV dataset from all music files in the database and publishes it to the Vempain Admin data store",
+			tags = "Data publish API"
+	)
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Music dataset published successfully",
+						 content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+											schema = @Schema(implementation = DataResponse.class))),
+			@ApiResponse(responseCode = "404", description = "No music files found", content = @Content),
+			@ApiResponse(responseCode = "500", description = "Internal server error", content = @Content),
+			@ApiResponse(responseCode = "401", description = "Unauthorized access", content = @Content)
+	})
+	@SecurityRequirement(name = "Bearer Authentication")
+	@PostMapping(path = BASE_PATH + "/music", produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<DataResponse> publishMusicDataset();
+
+	@Operation(
+			summary = "Generate and publish GPS time-series dataset for a directory",
+			description = "Generates a CSV time-series dataset from images with GPS metadata in the specified directory path and publishes it to Vempain Admin",
+			tags = "Data publish API"
+	)
+	@Parameter(name = "directoryPath", description = "URL-encoded relative directory path to scan for GPS-tagged images", example = "holidays_2024", required = true)
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "GPS time-series dataset published successfully",
+						 content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+											schema = @Schema(implementation = DataResponse.class))),
+			@ApiResponse(responseCode = "400", description = "Invalid directory path", content = @Content),
+			@ApiResponse(responseCode = "404", description = "No GPS-tagged images found in directory", content = @Content),
+			@ApiResponse(responseCode = "500", description = "Internal server error", content = @Content),
+			@ApiResponse(responseCode = "401", description = "Unauthorized access", content = @Content)
+	})
+	@SecurityRequirement(name = "Bearer Authentication")
+	@PostMapping(path = BASE_PATH + "/gps-timeseries/{directoryPath}", produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<DataResponse> publishGpsTimeSeries(@PathVariable("directoryPath") String directoryPath);
+}

--- a/service/src/main/java/fi/poltsi/vempain/file/service/DataService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/DataService.java
@@ -142,8 +142,13 @@ public class DataService {
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Directory path must not be empty");
 		}
 
-		// Normalise: ensure leading slash, no trailing slash
-		var normPath = "/" + directoryPath.replaceAll("^/+|/+$", "");
+		// Normalise: strip leading/trailing slash characters, then re-add one leading slash.
+		// Uses simple character-by-character scanning to avoid ReDoS risk with complex regex.
+		int start = 0;
+		int end   = directoryPath.length();
+		while (start < end && directoryPath.charAt(start) == '/') start++;
+		while (end > start && directoryPath.charAt(end - 1) == '/') end--;
+		var normPath = "/" + directoryPath.substring(start, end);
 		log.info("Generating GPS time-series dataset for directory: {}", normPath);
 
 		var images = imageFileRepository.findByFilePathWithGpsOrderedByTime(normPath);
@@ -163,16 +168,48 @@ public class DataService {
 	/**
 	 * Derives a valid data-store identifier from the directory path.
 	 * Identifier rules: starts with a-z, only a-z0-9_ allowed.
+	 *
+	 * <p>Uses only simple, non-backtracking regex patterns to avoid ReDoS risk.</p>
 	 */
 	String buildGpsIdentifier(String path) {
-		var cleaned = path.toLowerCase()
-						  .replaceAll("^[^a-z]+", "")   // strip leading non-alpha
-						  .replaceAll("[^a-z0-9_/]", "_") // replace invalid chars
-						  .replace('/', '_')              // slashes → underscore
-						  .replaceAll("_+", "_")          // collapse multiple underscores
-						  .replaceAll("_$", "");          // strip trailing underscore
-		var identifier = GPS_IDENTIFIER_PREFIX + cleaned;
-		// Ensure total length is reasonable (Admin identifier max is not specified but keep it sane)
+		// Lower-case and replace every non-alphanumeric/underscore/slash character with '_'
+		var lower    = path.toLowerCase();
+		var sb       = new StringBuilder(lower.length());
+		for (char c : lower.toCharArray()) {
+			if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_') {
+				sb.append(c);
+			} else {
+				sb.append('_');
+			}
+		}
+		// Collapse consecutive underscores (simple linear scan, no regex)
+		var collapsed = new StringBuilder();
+		boolean prevUnderscore = false;
+		for (int i = 0; i < sb.length(); i++) {
+			char c = sb.charAt(i);
+			if (c == '_') {
+				if (!prevUnderscore) {
+					collapsed.append(c);
+				}
+				prevUnderscore = true;
+			} else {
+				collapsed.append(c);
+				prevUnderscore = false;
+			}
+		}
+		// Strip leading characters until we find an [a-z] start
+		var str = collapsed.toString();
+		int alphaStart = 0;
+		while (alphaStart < str.length() && !(str.charAt(alphaStart) >= 'a' && str.charAt(alphaStart) <= 'z')) {
+			alphaStart++;
+		}
+		str = alphaStart < str.length() ? str.substring(alphaStart) : "dir";
+		// Strip trailing underscore
+		if (!str.isEmpty() && str.charAt(str.length() - 1) == '_') {
+			str = str.substring(0, str.length() - 1);
+		}
+		var identifier = GPS_IDENTIFIER_PREFIX + str;
+		// Ensure total length is reasonable
 		if (identifier.length() > 60) {
 			identifier = identifier.substring(0, 60);
 		}
@@ -256,19 +293,13 @@ public class DataService {
 	 * After creation/update, publishes the dataset to the site database.
 	 */
 	private DataResponse createOrUpdate(DataRequest request) {
-		DataResponse dataResponse;
 		try {
-			// Try to update first (the Admin side returns 404 if not found)
-			var updateResponse = vempainAdminDataClient.updateDataSet(request);
-			if (updateResponse != null && updateResponse.getStatusCode().is2xxSuccessful()) {
-				log.debug("Updated existing dataset: {}", request.getIdentifier());
-				dataResponse = updateResponse.getBody();
-			} else {
-				dataResponse = create(request);
-			}
+			// Try to update first (the Admin side throws FeignException.NotFound if dataset doesn't exist)
+			vempainAdminDataClient.updateDataSet(request);
+			log.debug("Updated existing dataset: {}", request.getIdentifier());
 		} catch (FeignException.NotFound e) {
 			log.debug("Dataset not found, creating: {}", request.getIdentifier());
-			dataResponse = create(request);
+			create(request);
 		} catch (FeignException e) {
 			log.error("Failed to create/update dataset '{}': status={}, msg={}",
 					  request.getIdentifier(), e.status(), e.getMessage());

--- a/service/src/main/java/fi/poltsi/vempain/file/service/DataService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/DataService.java
@@ -1,0 +1,333 @@
+package fi.poltsi.vempain.file.service;
+
+import feign.FeignException;
+import fi.poltsi.vempain.admin.api.request.DataRequest;
+import fi.poltsi.vempain.admin.api.response.DataResponse;
+import fi.poltsi.vempain.file.entity.ImageFileEntity;
+import fi.poltsi.vempain.file.entity.MusicFileEntity;
+import fi.poltsi.vempain.file.feign.VempainAdminDataClient;
+import fi.poltsi.vempain.file.repository.files.ImageFileRepository;
+import fi.poltsi.vempain.file.service.files.MusicFileService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+/**
+ * Service responsible for generating CSV datasets from the file database and
+ * publishing them to the Vempain Admin service via the {@link VempainAdminDataClient}.
+ *
+ * <p>Generated CSV data is ephemeral — it is produced on demand at API call time
+ * and is never persisted in the file database.</p>
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class DataService {
+
+	/** Identifier used in the Admin data store for the music dataset. */
+	static final String MUSIC_IDENTIFIER = "music_library";
+	/** Identifier prefix used for GPS time-series datasets per directory. */
+	static final String GPS_IDENTIFIER_PREFIX = "gps_timeseries_";
+
+	private static final DateTimeFormatter TIMESTAMP_FMT =
+			DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'").withZone(ZoneOffset.UTC);
+
+	private final MusicFileService      musicFileService;
+	private final ImageFileRepository   imageFileRepository;
+	private final VempainAdminDataClient vempainAdminDataClient;
+
+	// -----------------------------------------------------------------------
+	// Music dataset
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Generates a CSV from all music files, then creates or updates the dataset
+	 * in Vempain Admin and publishes it to the site database.
+	 *
+	 * @return the {@link DataResponse} returned by the Admin service after publishing
+	 */
+	public DataResponse generateAndPublishMusicDataset() {
+		log.info("Generating music dataset CSV");
+		var musicFiles = musicFileService.findAllOrdered();
+
+		if (musicFiles.isEmpty()) {
+			log.warn("No music files found in the database; skipping music dataset publication");
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No music files found in the database");
+		}
+
+		var csvData = buildMusicCsv(musicFiles);
+		var request = buildMusicDataRequest(csvData);
+		return createOrUpdate(request);
+	}
+
+	/**
+	 * Builds the CSV string for the music dataset.
+	 */
+	String buildMusicCsv(List<MusicFileEntity> musicFiles) {
+		var sb = new StringBuilder();
+		sb.append("artist,album,track_number,track_name,genre,duration_seconds\n");
+
+		for (var f : musicFiles) {
+			sb.append(escapeCsv(f.getArtist()))
+			  .append(',')
+			  .append(escapeCsv(f.getAlbum()))
+			  .append(',')
+			  .append(f.getTrackNumber() != null ? f.getTrackNumber() : "")
+			  .append(',')
+			  .append(escapeCsv(f.getTrackName()))
+			  .append(',')
+			  .append(escapeCsv(f.getGenre()))
+			  .append(',')
+			  .append(f.getDuration() != null ? f.getDuration().getSeconds() : "")
+			  .append('\n');
+		}
+		return sb.toString();
+	}
+
+	private DataRequest buildMusicDataRequest(String csvData) {
+		var request = new DataRequest();
+		request.setIdentifier(MUSIC_IDENTIFIER);
+		request.setType("tabulated");
+		request.setDescription("Music library — all music files with artist, album, track, genre and duration");
+		request.setColumnDefinitions(
+				"[{\"name\":\"artist\",\"type\":\"string\"},"
+				+ "{\"name\":\"album\",\"type\":\"string\"},"
+				+ "{\"name\":\"track_number\",\"type\":\"integer\"},"
+				+ "{\"name\":\"track_name\",\"type\":\"string\"},"
+				+ "{\"name\":\"genre\",\"type\":\"string\"},"
+				+ "{\"name\":\"duration_seconds\",\"type\":\"integer\"}]"
+		);
+		request.setCreateSql(
+				"CREATE TABLE website_data__" + MUSIC_IDENTIFIER
+				+ " (id BIGSERIAL PRIMARY KEY, artist VARCHAR(255), album VARCHAR(255),"
+				+ " track_number INTEGER, track_name VARCHAR(255), genre VARCHAR(100),"
+				+ " duration_seconds INTEGER)"
+		);
+		request.setFetchAllSql(
+				"SELECT id, artist, album, track_number, track_name, genre, duration_seconds"
+				+ " FROM website_data__" + MUSIC_IDENTIFIER
+				+ " ORDER BY artist, album, track_number"
+		);
+		request.setFetchSubsetSql(
+				"SELECT id, artist, album, track_number, track_name, genre, duration_seconds"
+				+ " FROM website_data__" + MUSIC_IDENTIFIER
+				+ " WHERE artist = :artist ORDER BY album, track_number"
+		);
+		request.setGenerated(Instant.now());
+		request.setCsvData(csvData);
+		return request;
+	}
+
+	// -----------------------------------------------------------------------
+	// GPS time-series dataset
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Generates a GPS time-series CSV from images with GPS data in the given
+	 * directory path, then creates or updates the dataset in Vempain Admin and
+	 * publishes it.
+	 *
+	 * @param directoryPath relative directory path (e.g. "/holidays/2024")
+	 * @return the {@link DataResponse} returned by the Admin service after publishing
+	 */
+	public DataResponse generateAndPublishGpsTimeSeries(String directoryPath) {
+		if (directoryPath == null || directoryPath.isBlank()) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Directory path must not be empty");
+		}
+
+		// Normalise: ensure leading slash, no trailing slash
+		var normPath = "/" + directoryPath.replaceAll("^/+|/+$", "");
+		log.info("Generating GPS time-series dataset for directory: {}", normPath);
+
+		var images = imageFileRepository.findByFilePathWithGpsOrderedByTime(normPath);
+
+		if (images.isEmpty()) {
+			log.warn("No GPS-tagged images found in directory: {}", normPath);
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+											  "No GPS-tagged images found in directory: " + normPath);
+		}
+
+		var identifier = buildGpsIdentifier(normPath);
+		var csvData    = buildGpsCsv(images);
+		var request    = buildGpsDataRequest(identifier, normPath, csvData);
+		return createOrUpdate(request);
+	}
+
+	/**
+	 * Derives a valid data-store identifier from the directory path.
+	 * Identifier rules: starts with a-z, only a-z0-9_ allowed.
+	 */
+	String buildGpsIdentifier(String path) {
+		var cleaned = path.toLowerCase()
+						  .replaceAll("^[^a-z]+", "")   // strip leading non-alpha
+						  .replaceAll("[^a-z0-9_/]", "_") // replace invalid chars
+						  .replace('/', '_')              // slashes → underscore
+						  .replaceAll("_+", "_")          // collapse multiple underscores
+						  .replaceAll("_$", "");          // strip trailing underscore
+		var identifier = GPS_IDENTIFIER_PREFIX + cleaned;
+		// Ensure total length is reasonable (Admin identifier max is not specified but keep it sane)
+		if (identifier.length() > 60) {
+			identifier = identifier.substring(0, 60);
+		}
+		return identifier;
+	}
+
+	/**
+	 * Builds the CSV string for the GPS time-series dataset.
+	 */
+	String buildGpsCsv(List<ImageFileEntity> images) {
+		var sb = new StringBuilder();
+		sb.append("timestamp,latitude,latitude_ref,longitude,longitude_ref,altitude,filename\n");
+
+		for (var img : images) {
+			var gps       = img.getGpsLocation();
+			var timestamp = img.getGpsTimestamp() != null
+							? TIMESTAMP_FMT.format(img.getGpsTimestamp())
+							: (img.getOriginalDatetime() != null
+							   ? TIMESTAMP_FMT.format(img.getOriginalDatetime())
+							   : "");
+
+			sb.append(escapeCsv(timestamp))
+			  .append(',')
+			  .append(gps.getLatitude() != null ? gps.getLatitude().toPlainString() : "")
+			  .append(',')
+			  .append(gps.getLatitudeRef() != null ? gps.getLatitudeRef() : "")
+			  .append(',')
+			  .append(gps.getLongitude() != null ? gps.getLongitude().toPlainString() : "")
+			  .append(',')
+			  .append(gps.getLongitudeRef() != null ? gps.getLongitudeRef() : "")
+			  .append(',')
+			  .append(gps.getAltitude() != null ? gps.getAltitude() : "")
+			  .append(',')
+			  .append(escapeCsv(img.getFilename()))
+			  .append('\n');
+		}
+		return sb.toString();
+	}
+
+	private DataRequest buildGpsDataRequest(String identifier, String path, String csvData) {
+		var tableBase = "website_data__" + identifier;
+		var request   = new DataRequest();
+		request.setIdentifier(identifier);
+		request.setType("time_series");
+		request.setDescription("GPS time-series for directory: " + path);
+		request.setColumnDefinitions(
+				"[{\"name\":\"timestamp\",\"type\":\"string\"},"
+				+ "{\"name\":\"latitude\",\"type\":\"decimal\"},"
+				+ "{\"name\":\"latitude_ref\",\"type\":\"string\"},"
+				+ "{\"name\":\"longitude\",\"type\":\"decimal\"},"
+				+ "{\"name\":\"longitude_ref\",\"type\":\"string\"},"
+				+ "{\"name\":\"altitude\",\"type\":\"decimal\"},"
+				+ "{\"name\":\"filename\",\"type\":\"string\"}]"
+		);
+		request.setCreateSql(
+				"CREATE TABLE " + tableBase
+				+ " (id BIGSERIAL PRIMARY KEY, timestamp TIMESTAMP,"
+				+ " latitude DECIMAL(15,5), latitude_ref CHAR(1),"
+				+ " longitude DECIMAL(15,5), longitude_ref CHAR(1),"
+				+ " altitude DOUBLE PRECISION, filename VARCHAR(255))"
+		);
+		request.setFetchAllSql(
+				"SELECT id, timestamp, latitude, latitude_ref, longitude, longitude_ref, altitude, filename"
+				+ " FROM " + tableBase + " ORDER BY timestamp ASC"
+		);
+		request.setFetchSubsetSql(
+				"SELECT id, timestamp, latitude, latitude_ref, longitude, longitude_ref, altitude, filename"
+				+ " FROM " + tableBase + " WHERE timestamp BETWEEN :from AND :to ORDER BY timestamp ASC"
+		);
+		request.setGenerated(Instant.now());
+		request.setCsvData(csvData);
+		return request;
+	}
+
+	// -----------------------------------------------------------------------
+	// Admin API interaction
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Attempts to update an existing dataset; if not found (404), creates a new one.
+	 * After creation/update, publishes the dataset to the site database.
+	 */
+	private DataResponse createOrUpdate(DataRequest request) {
+		DataResponse dataResponse;
+		try {
+			// Try to update first (the Admin side returns 404 if not found)
+			var updateResponse = vempainAdminDataClient.updateDataSet(request);
+			if (updateResponse != null && updateResponse.getStatusCode().is2xxSuccessful()) {
+				log.debug("Updated existing dataset: {}", request.getIdentifier());
+				dataResponse = updateResponse.getBody();
+			} else {
+				dataResponse = create(request);
+			}
+		} catch (FeignException.NotFound e) {
+			log.debug("Dataset not found, creating: {}", request.getIdentifier());
+			dataResponse = create(request);
+		} catch (FeignException e) {
+			log.error("Failed to create/update dataset '{}': status={}, msg={}",
+					  request.getIdentifier(), e.status(), e.getMessage());
+			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+											  "Failed to create/update dataset in Admin service: " + e.getMessage(), e);
+		}
+
+		return publish(request.getIdentifier());
+	}
+
+	private DataResponse create(DataRequest request) {
+		try {
+			var createResponse = vempainAdminDataClient.createDataSet(request);
+			if (createResponse == null || !createResponse.getStatusCode().is2xxSuccessful()) {
+				throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+												  "Failed to create dataset in Admin service");
+			}
+			log.debug("Created dataset: {}", request.getIdentifier());
+			return createResponse.getBody();
+		} catch (FeignException e) {
+			log.error("Failed to create dataset '{}': status={}, msg={}",
+					  request.getIdentifier(), e.status(), e.getMessage());
+			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+											  "Failed to create dataset in Admin service: " + e.getMessage(), e);
+		}
+	}
+
+	private DataResponse publish(String identifier) {
+		try {
+			var publishResponse = vempainAdminDataClient.publishDataSet(identifier);
+			if (publishResponse == null || !publishResponse.getStatusCode().is2xxSuccessful()) {
+				throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+												  "Failed to publish dataset in Admin service");
+			}
+			log.info("Published dataset: {}", identifier);
+			return publishResponse.getBody();
+		} catch (FeignException e) {
+			log.error("Failed to publish dataset '{}': status={}, msg={}",
+					  identifier, e.status(), e.getMessage());
+			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+											  "Failed to publish dataset in Admin service: " + e.getMessage(), e);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Utility
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Escapes a CSV field value: wraps in double-quotes if the value contains
+	 * a comma, double-quote, or newline, and doubles any internal double-quotes.
+	 */
+	static String escapeCsv(String value) {
+		if (value == null) {
+			return "";
+		}
+		if (value.contains(",") || value.contains("\"") || value.contains("\n") || value.contains("\r")) {
+			return "\"" + value.replace("\"", "\"\"") + "\"";
+		}
+		return value;
+	}
+}

--- a/service/src/main/java/fi/poltsi/vempain/file/service/DataService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/DataService.java
@@ -72,14 +72,20 @@ public class DataService {
 	 */
 	String buildMusicCsv(List<MusicFileEntity> musicFiles) {
 		var sb = new StringBuilder();
-		sb.append("artist,album,track_number,track_name,genre,duration_seconds\n");
+		sb.append("artist,album_artist,album,year,track_number,track_total,track_name,genre,duration_seconds\n");
 
 		for (var f : musicFiles) {
 			sb.append(escapeCsv(f.getArtist()))
 			  .append(',')
+			  .append(escapeCsv(f.getAlbumArtist()))
+			  .append(',')
 			  .append(escapeCsv(f.getAlbum()))
 			  .append(',')
+			  .append(f.getYear() != null ? f.getYear() : "")
+			  .append(',')
 			  .append(f.getTrackNumber() != null ? f.getTrackNumber() : "")
+			  .append(',')
+			  .append(f.getTrackTotal() != null ? f.getTrackTotal() : "")
 			  .append(',')
 			  .append(escapeCsv(f.getTrackName()))
 			  .append(',')
@@ -96,30 +102,42 @@ public class DataService {
 		request.setIdentifier(MUSIC_IDENTIFIER);
 		request.setType("tabulated");
 		request.setDescription("Music library — all music files with artist, album, track, genre and duration");
-		request.setColumnDefinitions(
-				"[{\"name\":\"artist\",\"type\":\"string\"},"
-				+ "{\"name\":\"album\",\"type\":\"string\"},"
-				+ "{\"name\":\"track_number\",\"type\":\"integer\"},"
-				+ "{\"name\":\"track_name\",\"type\":\"string\"},"
-				+ "{\"name\":\"genre\",\"type\":\"string\"},"
-				+ "{\"name\":\"duration_seconds\",\"type\":\"integer\"}]"
-		);
-		request.setCreateSql(
-				"CREATE TABLE website_data__" + MUSIC_IDENTIFIER
-				+ " (id BIGSERIAL PRIMARY KEY, artist VARCHAR(255), album VARCHAR(255),"
-				+ " track_number INTEGER, track_name VARCHAR(255), genre VARCHAR(100),"
-				+ " duration_seconds INTEGER)"
-		);
-		request.setFetchAllSql(
-				"SELECT id, artist, album, track_number, track_name, genre, duration_seconds"
-				+ " FROM website_data__" + MUSIC_IDENTIFIER
-				+ " ORDER BY artist, album, track_number"
-		);
-		request.setFetchSubsetSql(
-				"SELECT id, artist, album, track_number, track_name, genre, duration_seconds"
-				+ " FROM website_data__" + MUSIC_IDENTIFIER
-				+ " WHERE artist = :artist ORDER BY album, track_number"
-		);
+		request.setColumnDefinitions("""
+											 [{"name":"artist","type":"string"},
+											  {"name":"album_artist","type":"string"},
+											  {"name":"album","type":"string"},
+											  {"name":"year","type":"integer"},
+											  {"name":"track_number","type":"integer"},
+											  {"name":"track_total","type":"integer"},
+											  {"name":"track_name","type":"string"},
+											  {"name":"genre","type":"string"},
+											  {"name":"duration_seconds","type":"integer"}]
+											 """);
+		request.setCreateSql("""
+									 CREATE TABLE website_data__%s (
+									     id BIGSERIAL PRIMARY KEY,
+									     artist VARCHAR(255),
+									     album_artist VARCHAR(255),
+									     album VARCHAR(255),
+									     year INTEGER,
+									     track_number INTEGER,
+									     track_total INTEGER,
+									     track_name VARCHAR(255),
+									     genre VARCHAR(100),
+									     duration_seconds INTEGER
+									 )
+									 """.formatted(MUSIC_IDENTIFIER));
+		request.setFetchAllSql("""
+									   SELECT id, artist, album_artist, album, year, track_number, track_total, track_name, genre, duration_seconds
+									   FROM website_data__%s
+									   ORDER BY artist, album, track_number
+									   """.formatted(MUSIC_IDENTIFIER));
+		request.setFetchSubsetSql("""
+										  SELECT id, artist, album_artist, album, year, track_number, track_total, track_name, genre, duration_seconds
+										  FROM website_data__%s
+										  WHERE artist = :artist
+										  ORDER BY album, track_number
+										  """.formatted(MUSIC_IDENTIFIER));
 		request.setGenerated(Instant.now());
 		request.setCsvData(csvData);
 		return request;
@@ -148,7 +166,7 @@ public class DataService {
 		int end   = directoryPath.length();
 		while (start < end && directoryPath.charAt(start) == '/') start++;
 		while (end > start && directoryPath.charAt(end - 1) == '/') end--;
-		var normPath = "/" + directoryPath.substring(start, end);
+		var normPath = "/%s".formatted(directoryPath.substring(start, end));
 		log.info("Generating GPS time-series dataset for directory: {}", normPath);
 
 		var images = imageFileRepository.findByFilePathWithGpsOrderedByTime(normPath);
@@ -156,7 +174,10 @@ public class DataService {
 		if (images.isEmpty()) {
 			log.warn("No GPS-tagged images found in directory: {}", normPath);
 			throw new ResponseStatusException(HttpStatus.NOT_FOUND,
-											  "No GPS-tagged images found in directory: " + normPath);
+			                                  """
+													  No GPS-tagged images found in directory: %s
+													  """.formatted(normPath)
+			                                             .strip());
 		}
 
 		var identifier = buildGpsIdentifier(normPath);
@@ -208,7 +229,7 @@ public class DataService {
 		if (!str.isEmpty() && str.charAt(str.length() - 1) == '_') {
 			str = str.substring(0, str.length() - 1);
 		}
-		var identifier = GPS_IDENTIFIER_PREFIX + str;
+		var identifier = "%s%s".formatted(GPS_IDENTIFIER_PREFIX, str);
 		// Ensure total length is reasonable
 		if (identifier.length() > 60) {
 			identifier = identifier.substring(0, 60);
@@ -250,35 +271,46 @@ public class DataService {
 	}
 
 	private DataRequest buildGpsDataRequest(String identifier, String path, String csvData) {
-		var tableBase = "website_data__" + identifier;
+		var tableBase = "website_data__%s".formatted(identifier);
 		var request   = new DataRequest();
 		request.setIdentifier(identifier);
 		request.setType("time_series");
-		request.setDescription("GPS time-series for directory: " + path);
-		request.setColumnDefinitions(
-				"[{\"name\":\"timestamp\",\"type\":\"string\"},"
-				+ "{\"name\":\"latitude\",\"type\":\"decimal\"},"
-				+ "{\"name\":\"latitude_ref\",\"type\":\"string\"},"
-				+ "{\"name\":\"longitude\",\"type\":\"decimal\"},"
-				+ "{\"name\":\"longitude_ref\",\"type\":\"string\"},"
-				+ "{\"name\":\"altitude\",\"type\":\"decimal\"},"
-				+ "{\"name\":\"filename\",\"type\":\"string\"}]"
-		);
-		request.setCreateSql(
-				"CREATE TABLE " + tableBase
-				+ " (id BIGSERIAL PRIMARY KEY, timestamp TIMESTAMP,"
-				+ " latitude DECIMAL(15,5), latitude_ref CHAR(1),"
-				+ " longitude DECIMAL(15,5), longitude_ref CHAR(1),"
-				+ " altitude DOUBLE PRECISION, filename VARCHAR(255))"
-		);
-		request.setFetchAllSql(
-				"SELECT id, timestamp, latitude, latitude_ref, longitude, longitude_ref, altitude, filename"
-				+ " FROM " + tableBase + " ORDER BY timestamp ASC"
-		);
-		request.setFetchSubsetSql(
-				"SELECT id, timestamp, latitude, latitude_ref, longitude, longitude_ref, altitude, filename"
-				+ " FROM " + tableBase + " WHERE timestamp BETWEEN :from AND :to ORDER BY timestamp ASC"
-		);
+		request.setDescription("""
+									   GPS time-series for directory: %s
+									   """.formatted(path)
+		                                  .strip());
+		request.setColumnDefinitions("""
+											 [{"name":"timestamp","type":"string"},
+											  {"name":"latitude","type":"decimal"},
+											  {"name":"latitude_ref","type":"string"},
+											  {"name":"longitude","type":"decimal"},
+											  {"name":"longitude_ref","type":"string"},
+											  {"name":"altitude","type":"decimal"},
+											  {"name":"filename","type":"string"}]
+											 """);
+		request.setCreateSql("""
+									 CREATE TABLE %s (
+									     id BIGSERIAL PRIMARY KEY,
+									     timestamp TIMESTAMP,
+									     latitude DECIMAL(15,5),
+									     latitude_ref CHAR(1),
+									     longitude DECIMAL(15,5),
+									     longitude_ref CHAR(1),
+									     altitude DOUBLE PRECISION,
+									     filename VARCHAR(255)
+									 )
+									 """.formatted(tableBase));
+		request.setFetchAllSql("""
+									   SELECT id, timestamp, latitude, latitude_ref, longitude, longitude_ref, altitude, filename
+									   FROM %s
+									   ORDER BY timestamp ASC
+									   """.formatted(tableBase));
+		request.setFetchSubsetSql("""
+										  SELECT id, timestamp, latitude, latitude_ref, longitude, longitude_ref, altitude, filename
+										  FROM %s
+										  WHERE timestamp BETWEEN :from AND :to
+										  ORDER BY timestamp ASC
+										  """.formatted(tableBase));
 		request.setGenerated(Instant.now());
 		request.setCsvData(csvData);
 		return request;
@@ -293,26 +325,39 @@ public class DataService {
 	 * After creation/update, publishes the dataset to the site database.
 	 */
 	private DataResponse createOrUpdate(DataRequest request) {
+		var alreadyExists = true;
+
 		try {
-			// Try to update first (the Admin side throws FeignException.NotFound if dataset doesn't exist)
-			vempainAdminDataClient.updateDataSet(request);
-			log.debug("Updated existing dataset: {}", request.getIdentifier());
+			log.debug("Checking if the identifier {} already exists on Venpain Admin", request.getIdentifier());
+			vempainAdminDataClient.getDataSetByIdentifier(request.getIdentifier());
 		} catch (FeignException.NotFound e) {
-			log.debug("Dataset not found, creating: {}", request.getIdentifier());
-			create(request);
-		} catch (FeignException e) {
-			log.error("Failed to create/update dataset '{}': status={}, msg={}",
-					  request.getIdentifier(), e.status(), e.getMessage());
-			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
-											  "Failed to create/update dataset in Admin service: " + e.getMessage(), e);
+			alreadyExists = false;
 		}
 
-		return publish(request.getIdentifier());
+		if (alreadyExists) {
+			try {
+				log.debug("Updating existing dataset: {}", request.getIdentifier());
+				return vempainAdminDataClient.updateDataSet(request)
+				                             .getBody();
+			} catch (FeignException e) {
+				log.error("Failed to create/update dataset '{}': status={}, msg={}",
+				          request.getIdentifier(), e.status(), e.getMessage(), e);
+				throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+				                                  """
+														  Failed to create/update dataset in Admin service: %s
+														  """.formatted(e.getMessage())
+				                                             .strip(), e);
+			}
+		} else {
+			log.debug("identifier {} did not exist on Vempain Admin, creating it", request.getIdentifier());
+			return create(request);
+		}
 	}
 
 	private DataResponse create(DataRequest request) {
 		try {
 			var createResponse = vempainAdminDataClient.createDataSet(request);
+
 			if (createResponse == null || !createResponse.getStatusCode().is2xxSuccessful()) {
 				throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
 												  "Failed to create dataset in Admin service");
@@ -323,24 +368,10 @@ public class DataService {
 			log.error("Failed to create dataset '{}': status={}, msg={}",
 					  request.getIdentifier(), e.status(), e.getMessage());
 			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
-											  "Failed to create dataset in Admin service: " + e.getMessage(), e);
-		}
-	}
-
-	private DataResponse publish(String identifier) {
-		try {
-			var publishResponse = vempainAdminDataClient.publishDataSet(identifier);
-			if (publishResponse == null || !publishResponse.getStatusCode().is2xxSuccessful()) {
-				throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
-												  "Failed to publish dataset in Admin service");
-			}
-			log.info("Published dataset: {}", identifier);
-			return publishResponse.getBody();
-		} catch (FeignException e) {
-			log.error("Failed to publish dataset '{}': status={}, msg={}",
-					  identifier, e.status(), e.getMessage());
-			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
-											  "Failed to publish dataset in Admin service: " + e.getMessage(), e);
+			                                  """
+													  Failed to create dataset in Admin service: %s
+													  """.formatted(e.getMessage())
+			                                             .strip(), e);
 		}
 	}
 
@@ -357,7 +388,7 @@ public class DataService {
 			return "";
 		}
 		if (value.contains(",") || value.contains("\"") || value.contains("\n") || value.contains("\r")) {
-			return "\"" + value.replace("\"", "\"\"") + "\"";
+			return "\"%s\"".formatted(value.replace("\"", "\"\""));
 		}
 		return value;
 	}

--- a/service/src/main/java/fi/poltsi/vempain/file/service/DataService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/DataService.java
@@ -18,6 +18,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * Service responsible for generating CSV datasets from the file database and
@@ -38,6 +39,7 @@ public class DataService {
 
 	private static final DateTimeFormatter TIMESTAMP_FMT =
 			DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'").withZone(ZoneOffset.UTC);
+	private static final Pattern ADMIN_IDENTIFIER_PATTERN = Pattern.compile("^[a-z][a-z0-9_]*$");
 
 	private final MusicFileService      musicFileService;
 	private final ImageFileRepository   imageFileRepository;
@@ -187,6 +189,46 @@ public class DataService {
 	}
 
 	/**
+	 * Generates a GPS time-series CSV from images with GPS data in the given
+	 * file group, then creates or updates the dataset in Vempain Admin and publishes it.
+	 *
+	 * @param fileGroupId    ID of the file group containing images with GPS data
+	 * @param timeSeriesName the identifier/name of the time-series dataset
+	 * @return the {@link DataResponse} returned by the Admin service after publishing
+	 */
+	public DataResponse generateAndPublishGpsTimeSeriesByFileGroup(Long fileGroupId, String timeSeriesName) {
+		if (fileGroupId == null || fileGroupId <= 0) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "File group ID must be a positive number");
+		}
+
+		if (timeSeriesName == null || timeSeriesName.isBlank()) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Time series name must not be empty");
+		}
+
+		var normalizedIdentifier = normalizeAdminIdentifier(timeSeriesName);
+		if (!normalizedIdentifier.equals(timeSeriesName)) {
+			log.info("Normalized requested time-series name '{}' to Admin identifier '{}'", timeSeriesName, normalizedIdentifier);
+		}
+
+		log.info("Generating GPS time-series dataset for file group: {} with name: {}", fileGroupId, normalizedIdentifier);
+
+		var images = imageFileRepository.findByFileGroupIdWithGpsOrderedByTime(fileGroupId);
+
+		if (images.isEmpty()) {
+			log.warn("No GPS-tagged images found in file group: {}", fileGroupId);
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+			                                  """
+													  No GPS-tagged images found in file group: %d
+													  """.formatted(fileGroupId)
+			                                             .strip());
+		}
+
+		var csvData = buildGpsCsv(images);
+		var request = buildGpsDataRequest(normalizedIdentifier, "file group: " + fileGroupId, csvData);
+		return createOrUpdate(request);
+	}
+
+	/**
 	 * Derives a valid data-store identifier from the directory path.
 	 * Identifier rules: starts with a-z, only a-z0-9_ allowed.
 	 *
@@ -327,6 +369,10 @@ public class DataService {
 	private DataResponse createOrUpdate(DataRequest request) {
 		var alreadyExists = true;
 
+		log.debug("Prepared Admin DataRequest identifier='{}', type='{}', csv_header='{}', csv_length={} chars",
+		          request.getIdentifier(), request.getType(), csvHeaderPreview(request.getCsvData()),
+		          request.getCsvData() != null ? request.getCsvData().length() : 0);
+
 		try {
 			log.debug("Checking if the identifier {} already exists on Venpain Admin", request.getIdentifier());
 			vempainAdminDataClient.getDataSetByIdentifier(request.getIdentifier());
@@ -340,13 +386,9 @@ public class DataService {
 				return vempainAdminDataClient.updateDataSet(request)
 				                             .getBody();
 			} catch (FeignException e) {
-				log.error("Failed to create/update dataset '{}': status={}, msg={}",
-				          request.getIdentifier(), e.status(), e.getMessage(), e);
-				throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
-				                                  """
-														  Failed to create/update dataset in Admin service: %s
-														  """.formatted(e.getMessage())
-				                                             .strip(), e);
+				log.error("Failed to create/update dataset '{}': status={}, msg={}, body={}",
+				          request.getIdentifier(), e.status(), e.getMessage(), e.contentUTF8(), e);
+				throw mapAdminException(e, "create/update", request.getIdentifier());
 			}
 		} else {
 			log.debug("identifier {} did not exist on Vempain Admin, creating it", request.getIdentifier());
@@ -365,14 +407,85 @@ public class DataService {
 			log.debug("Created dataset: {}", request.getIdentifier());
 			return createResponse.getBody();
 		} catch (FeignException e) {
-			log.error("Failed to create dataset '{}': status={}, msg={}",
-					  request.getIdentifier(), e.status(), e.getMessage());
-			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
-			                                  """
-													  Failed to create dataset in Admin service: %s
-													  """.formatted(e.getMessage())
-			                                             .strip(), e);
+			log.error("Failed to create dataset '{}': status={}, msg={}, body={}",
+			          request.getIdentifier(), e.status(), e.getMessage(), e.contentUTF8());
+			throw mapAdminException(e, "create", request.getIdentifier());
 		}
+	}
+
+	private String normalizeAdminIdentifier(String candidate) {
+		var lower = candidate.trim()
+		                     .toLowerCase();
+		var sb    = new StringBuilder(lower.length());
+		for (char c : lower.toCharArray()) {
+			if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_') {
+				sb.append(c);
+			} else {
+				sb.append('_');
+			}
+		}
+
+		// Collapse duplicate underscores and trim the edges.
+		var     collapsed          = new StringBuilder(sb.length());
+		boolean previousUnderscore = false;
+		for (int i = 0; i < sb.length(); i++) {
+			char c = sb.charAt(i);
+			if (c == '_') {
+				if (!previousUnderscore) {
+					collapsed.append(c);
+				}
+				previousUnderscore = true;
+			} else {
+				collapsed.append(c);
+				previousUnderscore = false;
+			}
+		}
+		while (!collapsed.isEmpty() && collapsed.charAt(0) == '_') {
+			collapsed.deleteCharAt(0);
+		}
+		while (!collapsed.isEmpty() && collapsed.charAt(collapsed.length() - 1) == '_') {
+			collapsed.deleteCharAt(collapsed.length() - 1);
+		}
+
+		if (collapsed.isEmpty()) {
+			collapsed.append("gps_timeseries");
+		}
+		if (!(collapsed.charAt(0) >= 'a' && collapsed.charAt(0) <= 'z')) {
+			collapsed.insert(0, "gps_timeseries_");
+		}
+
+		var normalized = collapsed.toString();
+		if (normalized.length() > 60) {
+			normalized = normalized.substring(0, 60);
+		}
+
+		if (!ADMIN_IDENTIFIER_PATTERN.matcher(normalized)
+		                             .matches()) {
+			log.error("Failed to normalize Admin identifier from '{}' to a valid value. Produced '{}'", candidate, normalized);
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid time series name");
+		}
+		return normalized;
+	}
+
+	private String csvHeaderPreview(String csvData) {
+		if (csvData == null || csvData.isBlank()) {
+			return "";
+		}
+		var newlineIndex = csvData.indexOf('\n');
+		return newlineIndex >= 0 ? csvData.substring(0, newlineIndex)
+		                                  .trim() : csvData.trim();
+	}
+
+	private ResponseStatusException mapAdminException(FeignException exception, String action, String identifier) {
+		var body = exception.contentUTF8();
+		var reason = "Admin service failed to %s dataset '%s': %s".formatted(action, identifier,
+		                                                                     body != null && !body.isBlank() ? body : exception.getMessage());
+		return switch (exception.status()) {
+			case 400 -> new ResponseStatusException(HttpStatus.BAD_REQUEST, reason, exception);
+			case 404 -> new ResponseStatusException(HttpStatus.NOT_FOUND, reason, exception);
+			case 409 -> new ResponseStatusException(HttpStatus.CONFLICT, reason, exception);
+			default -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, reason, exception);
+		};
 	}
 
 	// -----------------------------------------------------------------------

--- a/service/src/main/java/fi/poltsi/vempain/file/service/DirectoryProcessorService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/DirectoryProcessorService.java
@@ -26,6 +26,7 @@ import fi.poltsi.vempain.file.entity.ImageFileEntity;
 import fi.poltsi.vempain.file.entity.InteractiveFileEntity;
 import fi.poltsi.vempain.file.entity.MetadataEntity;
 import fi.poltsi.vempain.file.entity.TagEntity;
+import fi.poltsi.vempain.file.entity.MusicFileEntity;
 import fi.poltsi.vempain.file.entity.ThumbFileEntity;
 import fi.poltsi.vempain.file.entity.VectorFileEntity;
 import fi.poltsi.vempain.file.entity.VideoFileEntity;
@@ -87,6 +88,12 @@ import static fi.poltsi.vempain.file.tools.MetadataTool.extractLabel;
 import static fi.poltsi.vempain.file.tools.MetadataTool.extractMetadataJson;
 import static fi.poltsi.vempain.file.tools.MetadataTool.extractMetadataJsonObject;
 import static fi.poltsi.vempain.file.tools.MetadataTool.extractMimetype;
+import static fi.poltsi.vempain.file.tools.MetadataTool.extractMusicAlbum;
+import static fi.poltsi.vempain.file.tools.MetadataTool.extractMusicArtist;
+import static fi.poltsi.vempain.file.tools.MetadataTool.extractMusicGenre;
+import static fi.poltsi.vempain.file.tools.MetadataTool.extractMusicTitle;
+import static fi.poltsi.vempain.file.tools.MetadataTool.extractMusicTrackNumber;
+import static fi.poltsi.vempain.file.tools.MetadataTool.hasMusicMetadata;
 import static fi.poltsi.vempain.file.tools.MetadataTool.extractOriginalDateTime;
 import static fi.poltsi.vempain.file.tools.MetadataTool.extractOriginalDocumentId;
 import static fi.poltsi.vempain.file.tools.MetadataTool.extractOriginalSecondFraction;
@@ -310,6 +317,7 @@ public class DirectoryProcessorService {
 			case ICON -> new IconFileEntity();
 			case IMAGE -> new ImageFileEntity();
 			case INTERACTIVE -> new InteractiveFileEntity();
+			case MUSIC -> new MusicFileEntity();
 			case THUMB -> new ThumbFileEntity();
 			case VECTOR -> new VectorFileEntity();
 			case VIDEO -> new VideoFileEntity();
@@ -435,6 +443,12 @@ public class DirectoryProcessorService {
 		var fileTypeEnum = FileTypeEnum.getFileTypeByMimetype(mimetype);
 		log.debug("Determined file type: {}", fileTypeEnum);
 
+		// Upgrade AUDIO to MUSIC if the file has music-specific metadata
+		if (fileTypeEnum == FileTypeEnum.AUDIO && hasMusicMetadata(jsonObject)) {
+			log.debug("Audio file has music metadata, upgrading type to MUSIC: {}", file.getName());
+			fileTypeEnum = FileTypeEnum.MUSIC;
+		}
+
 		if (fileTypeEnum == FileTypeEnum.UNKNOWN) {
 			log.warn("Unsupported file type: {}", file.getName());
 			return Boolean.FALSE;
@@ -466,6 +480,21 @@ public class DirectoryProcessorService {
 				audioFile.setChannels(extractAudioChannels(file));
 				fileRepository.save(audioFile);
 				linkFileToGroup(audioFile, fileGroup);
+			}
+			case MUSIC -> {
+				var musicFile = (MusicFileEntity) fileEntity;
+				musicFile.setDuration(extractAudioVideoDuration(file));
+				musicFile.setBitRate(extractAudioBitRate(file));
+				musicFile.setSampleRate(extractAudioSampleRate(file));
+				musicFile.setCodec(extractAudioCodec(file));
+				musicFile.setChannels(extractAudioChannels(file));
+				musicFile.setArtist(extractMusicArtist(jsonObject));
+				musicFile.setAlbum(extractMusicAlbum(jsonObject));
+				musicFile.setTrackName(extractMusicTitle(jsonObject));
+				musicFile.setTrackNumber(extractMusicTrackNumber(jsonObject));
+				musicFile.setGenre(extractMusicGenre(jsonObject));
+				fileRepository.save(musicFile);
+				linkFileToGroup(musicFile, fileGroup);
 			}
 			case BINARY -> {
 				var binary = (BinaryFileEntity) fileEntity;
@@ -725,6 +754,19 @@ public class DirectoryProcessorService {
 				audioFile.setSampleRate(extractAudioSampleRate(file));
 				audioFile.setCodec(extractAudioCodec(file));
 				audioFile.setChannels(extractAudioChannels(file));
+			}
+			case MUSIC -> {
+				var musicFile = (MusicFileEntity) existingFile;
+				musicFile.setDuration(extractAudioVideoDuration(file));
+				musicFile.setBitRate(extractAudioBitRate(file));
+				musicFile.setSampleRate(extractAudioSampleRate(file));
+				musicFile.setCodec(extractAudioCodec(file));
+				musicFile.setChannels(extractAudioChannels(file));
+				musicFile.setArtist(extractMusicArtist(jsonObject));
+				musicFile.setAlbum(extractMusicAlbum(jsonObject));
+				musicFile.setTrackName(extractMusicTitle(jsonObject));
+				musicFile.setTrackNumber(extractMusicTrackNumber(jsonObject));
+				musicFile.setGenre(extractMusicGenre(jsonObject));
 			}
 			case BINARY -> {
 				var binary = (BinaryFileEntity) existingFile;

--- a/service/src/main/java/fi/poltsi/vempain/file/service/DirectoryProcessorService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/DirectoryProcessorService.java
@@ -25,8 +25,8 @@ import fi.poltsi.vempain.file.entity.IconFileEntity;
 import fi.poltsi.vempain.file.entity.ImageFileEntity;
 import fi.poltsi.vempain.file.entity.InteractiveFileEntity;
 import fi.poltsi.vempain.file.entity.MetadataEntity;
-import fi.poltsi.vempain.file.entity.TagEntity;
 import fi.poltsi.vempain.file.entity.MusicFileEntity;
+import fi.poltsi.vempain.file.entity.TagEntity;
 import fi.poltsi.vempain.file.entity.ThumbFileEntity;
 import fi.poltsi.vempain.file.entity.VectorFileEntity;
 import fi.poltsi.vempain.file.entity.VideoFileEntity;
@@ -89,11 +89,13 @@ import static fi.poltsi.vempain.file.tools.MetadataTool.extractMetadataJson;
 import static fi.poltsi.vempain.file.tools.MetadataTool.extractMetadataJsonObject;
 import static fi.poltsi.vempain.file.tools.MetadataTool.extractMimetype;
 import static fi.poltsi.vempain.file.tools.MetadataTool.extractMusicAlbum;
+import static fi.poltsi.vempain.file.tools.MetadataTool.extractMusicAlbumArtist;
 import static fi.poltsi.vempain.file.tools.MetadataTool.extractMusicArtist;
 import static fi.poltsi.vempain.file.tools.MetadataTool.extractMusicGenre;
 import static fi.poltsi.vempain.file.tools.MetadataTool.extractMusicTitle;
 import static fi.poltsi.vempain.file.tools.MetadataTool.extractMusicTrackNumber;
-import static fi.poltsi.vempain.file.tools.MetadataTool.hasMusicMetadata;
+import static fi.poltsi.vempain.file.tools.MetadataTool.extractMusicTrackTotal;
+import static fi.poltsi.vempain.file.tools.MetadataTool.extractMusicYear;
 import static fi.poltsi.vempain.file.tools.MetadataTool.extractOriginalDateTime;
 import static fi.poltsi.vempain.file.tools.MetadataTool.extractOriginalDocumentId;
 import static fi.poltsi.vempain.file.tools.MetadataTool.extractOriginalSecondFraction;
@@ -104,6 +106,7 @@ import static fi.poltsi.vempain.file.tools.MetadataTool.extractSubjects;
 import static fi.poltsi.vempain.file.tools.MetadataTool.extractVectorLayersCount;
 import static fi.poltsi.vempain.file.tools.MetadataTool.extractVideoCodec;
 import static fi.poltsi.vempain.file.tools.MetadataTool.extractXYResolution;
+import static fi.poltsi.vempain.file.tools.MetadataTool.hasMusicMetadata;
 import static fi.poltsi.vempain.file.tools.MetadataTool.metadataToJsonObject;
 
 @Slf4j
@@ -489,9 +492,12 @@ public class DirectoryProcessorService {
 				musicFile.setCodec(extractAudioCodec(file));
 				musicFile.setChannels(extractAudioChannels(file));
 				musicFile.setArtist(extractMusicArtist(jsonObject));
+				musicFile.setAlbumArtist(extractMusicAlbumArtist(jsonObject));
 				musicFile.setAlbum(extractMusicAlbum(jsonObject));
+				musicFile.setYear(extractMusicYear(jsonObject));
 				musicFile.setTrackName(extractMusicTitle(jsonObject));
 				musicFile.setTrackNumber(extractMusicTrackNumber(jsonObject));
+				musicFile.setTrackTotal(extractMusicTrackTotal(jsonObject));
 				musicFile.setGenre(extractMusicGenre(jsonObject));
 				fileRepository.save(musicFile);
 				linkFileToGroup(musicFile, fileGroup);
@@ -763,9 +769,12 @@ public class DirectoryProcessorService {
 				musicFile.setCodec(extractAudioCodec(file));
 				musicFile.setChannels(extractAudioChannels(file));
 				musicFile.setArtist(extractMusicArtist(jsonObject));
+				musicFile.setAlbumArtist(extractMusicAlbumArtist(jsonObject));
 				musicFile.setAlbum(extractMusicAlbum(jsonObject));
+				musicFile.setYear(extractMusicYear(jsonObject));
 				musicFile.setTrackName(extractMusicTitle(jsonObject));
 				musicFile.setTrackNumber(extractMusicTrackNumber(jsonObject));
+				musicFile.setTrackTotal(extractMusicTrackTotal(jsonObject));
 				musicFile.setGenre(extractMusicGenre(jsonObject));
 			}
 			case BINARY -> {

--- a/service/src/main/java/fi/poltsi/vempain/file/service/files/MusicFileService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/files/MusicFileService.java
@@ -1,0 +1,72 @@
+package fi.poltsi.vempain.file.service.files;
+
+import fi.poltsi.vempain.auth.api.request.PagedRequest;
+import fi.poltsi.vempain.auth.api.response.PagedResponse;
+import fi.poltsi.vempain.file.api.response.files.MusicFileResponse;
+import fi.poltsi.vempain.file.entity.MusicFileEntity;
+import fi.poltsi.vempain.file.repository.files.MusicFileRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class MusicFileService {
+
+	private final MusicFileRepository musicFileRepository;
+
+	@Transactional(readOnly = true)
+	public PagedResponse<MusicFileResponse> findAll(PagedRequest pagedRequest) {
+		var                           safePage   = Math.max(0, pagedRequest.getPage());
+		var                           safeSize   = Math.min(Math.max(pagedRequest.getSize(), 1), 200);
+		var                           sort       = FileSearchHelper.buildSort(pagedRequest.getSortBy(), pagedRequest.getDirection());
+		Specification<MusicFileEntity> spec      = FileSearchHelper.buildSpecification(pagedRequest.getSearch(), Boolean.TRUE.equals(pagedRequest.getCaseSensitive()));
+		var                           pageable   = PageRequest.of(safePage, safeSize, sort);
+		var                           pageResult = musicFileRepository.findAll(spec, pageable);
+		var content = pageResult.getContent()
+								.stream()
+								.map(MusicFileEntity::toResponse)
+								.toList();
+		return PagedResponse.of(
+				content,
+				pageResult.getNumber(),
+				pageResult.getSize(),
+				pageResult.getTotalElements(),
+				pageResult.getTotalPages(),
+				pageResult.isFirst(),
+				pageResult.isLast()
+		);
+	}
+
+	@Transactional(readOnly = true)
+	public MusicFileResponse findById(long id) {
+		var entityOpt = musicFileRepository.findById(id);
+		return entityOpt.map(MusicFileEntity::toResponse)
+						.orElse(null);
+	}
+
+	public HttpStatus delete(long id) {
+		if (!musicFileRepository.existsById(id)) {
+			log.warn("Music file with id {} not found", id);
+			return HttpStatus.NOT_FOUND;
+		}
+		musicFileRepository.deleteById(id);
+		return HttpStatus.OK;
+	}
+
+	/**
+	 * Returns all music files ordered by artist, album, and track number — suitable
+	 * for CSV generation.
+	 */
+	@Transactional(readOnly = true)
+	public List<MusicFileEntity> findAllOrdered() {
+		return musicFileRepository.findAllByOrderByArtistAscAlbumAscTrackNumberAsc();
+	}
+}

--- a/service/src/main/java/fi/poltsi/vempain/file/tools/MetadataTool.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/tools/MetadataTool.java
@@ -287,6 +287,118 @@ public class MetadataTool {
 		return Integer.parseInt(getTagValue(output, "AudioChannels"));
 	}
 
+	/**
+	 * Extract the artist/performer from audio file metadata (ID3, Vorbis, etc.)
+	 *
+	 * @param jsonObject Extracted JSON formatted metadata
+	 * @return Artist string or null if not found
+	 */
+	public static String extractMusicArtist(JSONObject jsonObject) {
+		var locations = new HashMap<String, List<String>>();
+		locations.put("ID3", List.of("Artist", "TPE1", "TPE2", "AlbumArtist", "Performer"));
+		locations.put("Vorbis", List.of("Artist", "Performer", "AlbumArtist"));
+		locations.put("iTunes", List.of("Artist"));
+		locations.put("QuickTime", List.of("Artist", "TPE1"));
+		locations.put("RIFF", List.of("Artist", "IART"));
+		locations.put("XMP-dm", List.of("Artist", "AlbumArtist"));
+		return extractJsonString(jsonObject, locations);
+	}
+
+	/**
+	 * Extract the album name from audio file metadata.
+	 *
+	 * @param jsonObject Extracted JSON formatted metadata
+	 * @return Album name string or null if not found
+	 */
+	public static String extractMusicAlbum(JSONObject jsonObject) {
+		var locations = new HashMap<String, List<String>>();
+		locations.put("ID3", List.of("Album", "TALB"));
+		locations.put("Vorbis", List.of("Album"));
+		locations.put("iTunes", List.of("Album"));
+		locations.put("QuickTime", List.of("Album", "TALB"));
+		locations.put("RIFF", List.of("Product", "IPRD"));
+		locations.put("XMP-dm", List.of("Album"));
+		return extractJsonString(jsonObject, locations);
+	}
+
+	/**
+	 * Extract the track title from audio file metadata.
+	 *
+	 * @param jsonObject Extracted JSON formatted metadata
+	 * @return Track title string or null if not found
+	 */
+	public static String extractMusicTitle(JSONObject jsonObject) {
+		var locations = new HashMap<String, List<String>>();
+		locations.put("ID3", List.of("Title", "TIT2", "TIT1"));
+		locations.put("Vorbis", List.of("Title"));
+		locations.put("iTunes", List.of("Title"));
+		locations.put("QuickTime", List.of("Title", "TIT2"));
+		locations.put("RIFF", List.of("Name", "INAM"));
+		locations.put("XMP-dm", List.of("TrackName"));
+		return extractJsonString(jsonObject, locations);
+	}
+
+	/**
+	 * Extract the track number from audio file metadata.
+	 *
+	 * @param jsonObject Extracted JSON formatted metadata
+	 * @return Track number or null if not found or not parseable
+	 */
+	public static Integer extractMusicTrackNumber(JSONObject jsonObject) {
+		var locations = new HashMap<String, List<String>>();
+		locations.put("ID3", List.of("TrackNumber", "TRCK"));
+		locations.put("Vorbis", List.of("Tracknumber", "Track"));
+		locations.put("iTunes", List.of("TrackNumber"));
+		locations.put("QuickTime", List.of("TrackNumber", "TRCK"));
+		locations.put("XMP-dm", List.of("TrackNumber"));
+
+		var trackStr = extractJsonString(jsonObject, locations);
+		if (trackStr == null || trackStr.isBlank()) {
+			return null;
+		}
+		// Track may be in format "1/12" (track/total); take only the track part
+		var parts = trackStr.split("/");
+		try {
+			return Integer.parseInt(parts[0].trim());
+		} catch (NumberFormatException e) {
+			log.debug("Could not parse track number from: {}", trackStr);
+			return null;
+		}
+	}
+
+	/**
+	 * Extract the genre from audio file metadata.
+	 *
+	 * @param jsonObject Extracted JSON formatted metadata
+	 * @return Genre string or null if not found
+	 */
+	public static String extractMusicGenre(JSONObject jsonObject) {
+		var locations = new HashMap<String, List<String>>();
+		locations.put("ID3", List.of("Genre", "TCON"));
+		locations.put("Vorbis", List.of("Genre"));
+		locations.put("iTunes", List.of("Genre"));
+		locations.put("QuickTime", List.of("Genre", "TCON"));
+		locations.put("RIFF", List.of("Genre", "IGNR"));
+		locations.put("XMP-dm", List.of("Genre"));
+		return extractJsonString(jsonObject, locations);
+	}
+
+	/**
+	 * Checks whether the given metadata JSON object contains music-specific metadata
+	 * (at minimum an artist or title field).
+	 *
+	 * @param jsonObject Extracted JSON formatted metadata
+	 * @return true if music metadata is present, false otherwise
+	 */
+	public static boolean hasMusicMetadata(JSONObject jsonObject) {
+		if (jsonObject == null) {
+			return false;
+		}
+		return extractMusicArtist(jsonObject) != null
+			   || extractMusicTitle(jsonObject) != null
+			   || extractMusicAlbum(jsonObject) != null;
+	}
+
 	public static int extractDocumentPageCount(File file) throws IOException {
 		var output = runExifTool(file, "-PageCount");
 		return Integer.parseInt(getTagValue(output, "PageCount"));

--- a/service/src/main/java/fi/poltsi/vempain/file/tools/MetadataTool.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/tools/MetadataTool.java
@@ -23,7 +23,6 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -75,6 +74,7 @@ public class MetadataTool {
 
 	// GPS coordinate precision
 	private static final int GPS_DECIMAL_PRECISION = 5;
+	private static final long MAX_DURATION_SECONDS = 99_999L;
 
 	public static String extractMetadataJson(File file) throws IOException {
 		return runExifTool(file, "-a", "-u", "-ee", "-api", "RequestAll=3", "-g1", "-J");
@@ -222,59 +222,24 @@ public class MetadataTool {
 	public static Duration extractAudioVideoDuration(File file) throws IOException {
 		var output = runExifTool(file, "-Duration");
 		var durationStr = getTagValue(output, "Duration");
-
-		// If the string is empty or null, return 0
-		if (durationStr == null || durationStr.isBlank()) {
-			return Duration.of(0L, ChronoUnit.MILLIS);
-		}
-
-		// If the string contains colons, it's in a time format (hh:mm:ss or mm:ss)
-		if (durationStr.contains(":")) {
-			String[] parts   = durationStr.split(":");
-			long seconds = 0L;
-
-			if (parts.length == 3) {
-				// Format: hh:mm:ss.ms
-				seconds += Long.parseLong(parts[0]) * 3600; // Hours to seconds
-				seconds += Long.parseLong(parts[1]) * 60;   // Minutes to seconds
-				seconds += Long.parseLong(parts[2]);        // Seconds
-			} else if (parts.length == 2) {
-				// Format: mm:ss.ms
-				seconds += Long.parseLong(parts[0]) * 60;   // Minutes to seconds
-				seconds += Long.parseLong(parts[1]);        // Seconds
-			}
-
-			return Duration.of(seconds, ChronoUnit.SECONDS);
-		} else {
-			// Check if the string contains a time qualifier like "s", "sec", "seconds"
-			String trimmedStr = durationStr.trim();
-			if (trimmedStr.endsWith(" s") ||
-				trimmedStr.endsWith(" sec") ||
-				trimmedStr.endsWith(" seconds")) {
-
-				// Extract the numeric part before the qualifier
-				int spaceIndex = trimmedStr.lastIndexOf(' ');
-				if (spaceIndex > 0) {
-					String numericPart = trimmedStr.substring(0, spaceIndex);
-					var seconds = Long.parseLong(numericPart);
-					return Duration.of(seconds, ChronoUnit.SECONDS);
-				}
-			}
-
-			// It's already in seconds format (possibly with decimal)
-			var seconds = Long.parseLong(durationStr);
-			return Duration.of(seconds, ChronoUnit.SECONDS);
-		}
+		return durationFromString(durationStr);
 	}
 
 	public static int extractAudioBitRate(File file) throws IOException {
-		var output = runExifTool(file, "-AudioBitrate");
-		return Integer.parseInt(getTagValue(output, "AudioBitrate"));
+		var output = runExifTool(file, "-AudioBitrate", "-AvgBitrate", "-NominalBitrate", "-BitRate", "-Duration");
+		return parseAudioBitRateKbps(output, file.length());
 	}
 
 	public static int extractAudioSampleRate(File file) throws IOException {
-		var output = runExifTool(file, "-AudioSampleRate");
-		return Integer.parseInt(getTagValue(output, "AudioSampleRate"));
+		var output = runExifTool(file, "-AudioSampleRate", "-SampleRate");
+		var parsed = parseIntegerWithUnits(getTagValue(output, "AudioSampleRate"));
+
+		if (parsed != null && parsed > 0) {
+			return parsed;
+		}
+
+		parsed = parseIntegerWithUnits(getTagValue(output, "SampleRate"));
+		return parsed != null ? parsed : 0;
 	}
 
 	public static String extractAudioCodec(File file) throws IOException {
@@ -283,8 +248,15 @@ public class MetadataTool {
 	}
 
 	public static int extractAudioChannels(File file) throws IOException {
-		var output = runExifTool(file, "-AudioChannels");
-		return Integer.parseInt(getTagValue(output, "AudioChannels"));
+		var output = runExifTool(file, "-AudioChannels", "-Channels");
+		var parsed = parseIntegerWithUnits(getTagValue(output, "AudioChannels"));
+
+		if (parsed != null && parsed > 0) {
+			return parsed;
+		}
+
+		parsed = parseIntegerWithUnits(getTagValue(output, "Channels"));
+		return parsed != null ? parsed : 0;
 	}
 
 	/**
@@ -322,6 +294,63 @@ public class MetadataTool {
 	}
 
 	/**
+	 * Extract the album artist from audio file metadata.
+	 * Falls back to the track artist if no dedicated album artist field exists.
+	 */
+	public static String extractMusicAlbumArtist(JSONObject jsonObject) {
+		var locations = new HashMap<String, List<String>>();
+		locations.put("ID3", List.of("AlbumArtist", "Albumartist", "Band", "TPE2", "Artist"));
+		locations.put("Vorbis", List.of("AlbumArtist", "Albumartist", "Artist"));
+		locations.put("iTunes", List.of("AlbumArtist", "Artist"));
+		locations.put("QuickTime", List.of("AlbumArtist", "Artist", "TPE2"));
+		locations.put("RIFF", List.of("Band", "Artist", "IART"));
+		locations.put("XMP-dm", List.of("AlbumArtist", "Artist"));
+		return extractJsonString(jsonObject, locations);
+	}
+
+	/**
+	 * Extract the release year from audio file metadata.
+	 * Only the year part is returned, even if a full date is stored.
+	 */
+	public static Integer extractMusicYear(JSONObject jsonObject) {
+		var locations = new HashMap<String, List<String>>();
+		locations.put("ID3", List.of("Year", "Date", "TDRC"));
+		locations.put("Vorbis", List.of("Date", "Year"));
+		locations.put("iTunes", List.of("Year", "Date"));
+		locations.put("QuickTime", List.of("Year", "Date"));
+		locations.put("Composite", List.of("DateTimeOriginal"));
+		locations.put("XMP-dm", List.of("ReleaseDate"));
+
+		var yearValue = extractJsonScalar(jsonObject, locations);
+		if (yearValue == null) {
+			return null;
+		}
+
+		if (yearValue instanceof Number number) {
+			return number.intValue();
+		}
+
+		var yearString = Objects.toString(yearValue, null);
+		if (yearString == null || yearString.isBlank()) {
+			return 0;
+		}
+
+		var matcher = java.util.regex.Pattern.compile("(\\d{4})")
+		                                     .matcher(yearString);
+		if (matcher.find()) {
+			return Integer.parseInt(matcher.group(1));
+		}
+
+		var fallback = parseIntegerWithUnits(yearString);
+		if (fallback != null) {
+			return fallback;
+		}
+
+		log.debug("Could not parse music year from: {}", yearString);
+		return 0;
+	}
+
+	/**
 	 * Extract the track title from audio file metadata.
 	 *
 	 * @param jsonObject Extracted JSON formatted metadata
@@ -347,23 +376,85 @@ public class MetadataTool {
 	public static Integer extractMusicTrackNumber(JSONObject jsonObject) {
 		var locations = new HashMap<String, List<String>>();
 		locations.put("ID3", List.of("TrackNumber", "TRCK"));
-		locations.put("Vorbis", List.of("Tracknumber", "Track"));
+		locations.put("Vorbis", List.of("TrackNumber", "Tracknumber", "Track"));
 		locations.put("iTunes", List.of("TrackNumber"));
 		locations.put("QuickTime", List.of("TrackNumber", "TRCK"));
 		locations.put("XMP-dm", List.of("TrackNumber"));
 
-		var trackStr = extractJsonString(jsonObject, locations);
-		if (trackStr == null || trackStr.isBlank()) {
+		var trackValue = extractJsonScalar(jsonObject, locations);
+		if (trackValue == null) {
 			return null;
+		}
+
+		if (trackValue instanceof Number number) {
+			return number.intValue();
+		}
+
+		var trackStr = Objects.toString(trackValue, null);
+		if (trackStr == null || trackStr.isBlank()) {
+			return 0;
 		}
 		// Track may be in format "1/12" (track/total); take only the track part
 		var parts = trackStr.split("/");
 		try {
 			return Integer.parseInt(parts[0].trim());
 		} catch (NumberFormatException e) {
+			var fallback = parseIntegerWithUnits(trackStr);
+			if (fallback != null) {
+				return fallback;
+			}
 			log.debug("Could not parse track number from: {}", trackStr);
+			return 0;
+		}
+	}
+
+	/**
+	 * Extract the total track count from audio file metadata.
+	 */
+	public static Integer extractMusicTrackTotal(JSONObject jsonObject) {
+		var locations = new HashMap<String, List<String>>();
+		locations.put("ID3", List.of("TrackTotal", "Track", "TRCK"));
+		locations.put("Vorbis", List.of("TrackTotal", "Tracktotal", "TrackNumber", "Track"));
+		locations.put("iTunes", List.of("TrackTotal", "TrackCount", "TrackNumber"));
+		locations.put("QuickTime", List.of("TrackTotal", "TrackNumber", "TRCK"));
+		locations.put("XMP-dm", List.of("TrackTotal", "TrackNumber"));
+
+		var trackValue = extractJsonScalar(jsonObject, locations);
+		if (trackValue == null) {
 			return null;
 		}
+
+		if (trackValue instanceof Number number) {
+			return number.intValue();
+		}
+
+		var trackStr = Objects.toString(trackValue, null);
+		if (trackStr == null || trackStr.isBlank()) {
+			return 0;
+		}
+
+		if (trackStr.contains("/")) {
+			var parts = trackStr.split("/");
+			if (parts.length > 1) {
+				var totalPart = parts[1].trim();
+				try {
+					return Integer.parseInt(totalPart);
+				} catch (NumberFormatException ignored) {
+					var fallbackTotal = parseIntegerWithUnits(totalPart);
+					if (fallbackTotal != null) {
+						return fallbackTotal;
+					}
+				}
+			}
+		}
+
+		var fallback = parseIntegerWithUnits(trackStr);
+		if (fallback != null) {
+			return fallback;
+		}
+
+		log.debug("Could not parse track total from: {}", trackStr);
+		return 0;
 	}
 
 	/**
@@ -396,7 +487,8 @@ public class MetadataTool {
 		}
 		return extractMusicArtist(jsonObject) != null
 			   || extractMusicTitle(jsonObject) != null
-			   || extractMusicAlbum(jsonObject) != null;
+		       || extractMusicAlbum(jsonObject) != null
+		       || extractMusicGenre(jsonObject) != null;
 	}
 
 	public static int extractDocumentPageCount(File file) throws IOException {
@@ -1094,9 +1186,16 @@ public class MetadataTool {
 		for (Map.Entry<String, List<String>> location : locations.entrySet()) {
 			for (String key : location.getValue()) {
 				if (jsonObject.has(location.getKey()) && jsonObject.getJSONObject(location.getKey())
-																   .has(key)) {
-					return jsonObject.getJSONObject(location.getKey())
-									 .getString(key);
+				                                                   .has(key)) {
+					// Use opt() so that numeric values (e.g. a track title stored as an integer)
+					// are converted to String instead of throwing JSONException.
+					return Objects.toString(jsonObject.getJSONObject(location.getKey())
+					                                  .opt(key), null);
+				}
+
+				// Also support flat exiftool JSON where fields are on root level.
+				if (jsonObject.has(key) && !(jsonObject.opt(key) instanceof JSONObject)) {
+					return Objects.toString(jsonObject.opt(key), null);
 				}
 			}
 		}
@@ -1126,6 +1225,38 @@ public class MetadataTool {
 							log.error("Key {} exists but can not be parsed as number", key);
 						}
 					}
+				}
+
+				if (jsonObject.has(key) && !(jsonObject.opt(key) instanceof JSONObject)) {
+					var flat = jsonObject.opt(key);
+					if (flat instanceof Number n) {
+						return n;
+					}
+					var parsed = parseDoubleSafe(Objects.toString(flat, null));
+					if (parsed != null) {
+						return parsed;
+					}
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private static Object extractJsonScalar(JSONObject jsonObject, Map<String, List<String>> locations) {
+		for (Map.Entry<String, List<String>> location : locations.entrySet()) {
+			for (String key : location.getValue()) {
+				if (jsonObject.has(location.getKey()) && jsonObject.getJSONObject(location.getKey())
+				                                                   .has(key)) {
+					var value = jsonObject.getJSONObject(location.getKey())
+					                      .opt(key);
+					if (!(value instanceof JSONObject) && value != null) {
+						return value;
+					}
+				}
+
+				if (jsonObject.has(key) && !(jsonObject.opt(key) instanceof JSONObject)) {
+					return jsonObject.opt(key);
 				}
 			}
 		}
@@ -1168,6 +1299,89 @@ public class MetadataTool {
 		}
 
 		return "";
+	}
+
+	static Duration durationFromString(String durationStr) {
+		if (durationStr == null || durationStr.isBlank()) {
+			return Duration.ZERO;
+		}
+
+		var normalized = durationStr.trim();
+
+		// Exiftool may emit "0:02:50 (approx)".
+		var approxIndex = normalized.indexOf(' ');
+		if (approxIndex > 0) {
+			normalized = normalized.substring(0, approxIndex)
+			                       .trim();
+		}
+
+		if (normalized.contains(":")) {
+			var parts = normalized.split(":");
+			try {
+				double seconds;
+				if (parts.length == 3) {
+					seconds = Double.parseDouble(parts[0].trim()) * 3600
+					          + Double.parseDouble(parts[1].trim()) * 60
+					          + Double.parseDouble(parts[2].trim());
+				} else if (parts.length == 2) {
+					seconds = Double.parseDouble(parts[0].trim()) * 60
+					          + Double.parseDouble(parts[1].trim());
+				} else {
+					return Duration.ZERO;
+				}
+				return clampDurationToSchema(Duration.ofMillis(Math.round(seconds * 1000)));
+			} catch (NumberFormatException e) {
+				log.warn("Could not parse duration string: {}", durationStr);
+				return Duration.ZERO;
+			}
+		}
+
+		var numericPart = normalized.replaceAll("(?i)\\s*(seconds?|sec|s)$", "")
+		                            .trim();
+		var seconds = parseDoubleSafe(numericPart);
+		if (seconds == null || seconds < 0) {
+			return Duration.ZERO;
+		}
+
+		return clampDurationToSchema(Duration.ofMillis(Math.round(seconds * 1000)));
+	}
+
+	private static Duration clampDurationToSchema(Duration duration) {
+		if (duration == null || duration.isNegative()) {
+			return Duration.ZERO;
+		}
+		if (duration.getSeconds() > MAX_DURATION_SECONDS) {
+			log.warn("Duration {} exceeds schema max {} seconds, clamping", duration, MAX_DURATION_SECONDS);
+			return Duration.ofSeconds(MAX_DURATION_SECONDS);
+		}
+		return duration;
+	}
+
+	static int parseAudioBitRateKbps(String exifJsonOutput, long fallbackFileSizeBytes) {
+		var primary = parseIntegerWithUnits(getTagValue(exifJsonOutput, "AudioBitrate"));
+		if (primary != null && primary > 0) {
+			return primary;
+		}
+
+		for (var tag : List.of("AvgBitrate", "NominalBitrate", "BitRate")) {
+			var parsed = parseIntegerWithUnits(getTagValue(exifJsonOutput, tag));
+			if (parsed != null && parsed > 0) {
+				return parsed;
+			}
+		}
+
+		var duration = durationFromString(getTagValue(exifJsonOutput, "Duration"));
+		if (duration.isZero() || duration.isNegative() || fallbackFileSizeBytes <= 0) {
+			return 0;
+		}
+
+		double seconds = duration.toMillis() / 1000.0;
+		if (seconds <= 0) {
+			return 0;
+		}
+
+		var calculated = (int) Math.round((fallbackFileSizeBytes * 8.0) / seconds / 1000.0);
+		return Math.max(calculated, 0);
 	}
 
 	public static Instant dateTimeParser(String dateTimeString) {
@@ -1481,6 +1695,33 @@ public class MetadataTool {
 				return null;
 			}
 			return Integer.parseInt(cleaned);
+		} catch (Exception e) {
+			return null;
+		}
+	}
+
+	private static Integer parseIntegerWithUnits(String s) {
+		if (s == null || s.isBlank()) {
+			return null;
+		}
+
+		var trimmed = s.trim();
+		try {
+			var matcher = java.util.regex.Pattern.compile("-?\\d+(?:[.,]\\d+)?")
+			                                     .matcher(trimmed);
+			if (!matcher.find()) {
+				return null;
+			}
+
+			var value = Double.parseDouble(matcher.group()
+			                                      .replace(',', '.'));
+			var lower = trimmed.toLowerCase();
+
+			if (lower.contains("mbps")) {
+				value *= 1000.0;
+			}
+
+			return (int) Math.round(value);
 		} catch (Exception e) {
 			return null;
 		}

--- a/service/src/main/resources/db/migration/V1002__music_files.sql
+++ b/service/src/main/resources/db/migration/V1002__music_files.sql
@@ -4,13 +4,18 @@ CREATE TABLE music_files
 (
     id           BIGINT PRIMARY KEY,
     artist       VARCHAR(255),
+    album_artist VARCHAR(255),
     album        VARCHAR(255),
+    year         INT,
     track_name   VARCHAR(255),
     track_number INT,
+    track_total  INT,
     genre        VARCHAR(100),
     FOREIGN KEY (id) REFERENCES audio_files (id) ON DELETE CASCADE
 );
 
 CREATE INDEX idx_music_files_artist ON music_files (artist);
+CREATE INDEX idx_music_files_album_artist ON music_files (album_artist);
 CREATE INDEX idx_music_files_album ON music_files (album);
+CREATE INDEX idx_music_files_year ON music_files (year);
 CREATE INDEX idx_music_files_genre ON music_files (genre);

--- a/service/src/main/resources/db/migration/V1002__music_files.sql
+++ b/service/src/main/resources/db/migration/V1002__music_files.sql
@@ -1,0 +1,16 @@
+-- Music files table: stores music-specific metadata for audio files that have
+-- artist/album/track information. Inherits from audio_files via JOINED strategy.
+CREATE TABLE music_files
+(
+    id           BIGINT PRIMARY KEY,
+    artist       VARCHAR(255),
+    album        VARCHAR(255),
+    track_name   VARCHAR(255),
+    track_number INT,
+    genre        VARCHAR(100),
+    FOREIGN KEY (id) REFERENCES audio_files (id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_music_files_artist ON music_files (artist);
+CREATE INDEX idx_music_files_album ON music_files (album);
+CREATE INDEX idx_music_files_genre ON music_files (genre);

--- a/service/src/test/java/fi/poltsi/vempain/file/controller/files/MusicFileControllerCTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/controller/files/MusicFileControllerCTC.java
@@ -1,0 +1,97 @@
+package fi.poltsi.vempain.file.controller.files;
+
+import fi.poltsi.vempain.file.controller.AbstractControllerCTC;
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration test for {@link MusicFileController}.
+ *
+ * <p>Music files require entries in all three tables in the JOINED inheritance hierarchy:
+ * {@code files}, {@code audio_files}, and {@code music_files}. Because the {@link FileTypeControllersCTC}
+ * parameterized test only supports a single INSERT statement per type, music is covered here.
+ */
+class MusicFileControllerCTC extends AbstractControllerCTC {
+
+	private static final long TEST_ID = 9010L;
+
+	// -----------------------------------------------------------------------
+	// Test 1: paged endpoint returns 200 with valid structure
+	// -----------------------------------------------------------------------
+
+	@Test
+	void findAll_returns200WithValidPageShape() throws Exception {
+		doPost("/files/music/paged", "{\"page\":0,\"size\":10}")
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.content").isArray());
+	}
+
+	// -----------------------------------------------------------------------
+	// Test 2: findById 404 for missing id
+	// -----------------------------------------------------------------------
+
+	@Test
+	void findById_returns404_whenRecordDoesNotExist() throws Exception {
+		doGet("/files/music/99999")
+				.andExpect(status().isNotFound());
+	}
+
+	// -----------------------------------------------------------------------
+	// Test 3: findById 200 for seeded record
+	// -----------------------------------------------------------------------
+
+	@Test
+	void findById_returns200_whenRecordExists() throws Exception {
+		seedMusicRow(TEST_ID);
+		try {
+			doGet("/files/music/" + TEST_ID)
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.id").value(TEST_ID))
+					.andExpect(jsonPath("$.file_type").value("MUSIC"))
+					.andExpect(jsonPath("$.artist").value("Test Artist"));
+		} finally {
+			deleteFileRow(TEST_ID);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Test 4: delete 200 for seeded record
+	// -----------------------------------------------------------------------
+
+	@Test
+	void delete_returns200_whenRecordExists() throws Exception {
+		seedMusicRow(TEST_ID);
+		try {
+			doDelete("/files/music/" + TEST_ID)
+					.andExpect(status().isOk());
+		} finally {
+			jdbcTemplate.update("DELETE FROM files WHERE id = ?", TEST_ID);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Test 5: delete 404 for missing id
+	// -----------------------------------------------------------------------
+
+	@Test
+	void delete_returns404_whenRecordDoesNotExist() throws Exception {
+		doDelete("/files/music/99999")
+				.andExpect(status().isNotFound());
+	}
+
+	// -----------------------------------------------------------------------
+	// Seed helper
+	// -----------------------------------------------------------------------
+
+	private void seedMusicRow(long id) {
+		seedFileRow(id, "MUSIC", "audio/mpeg", "test-music.mp3", "/test/music");
+		jdbcTemplate.update(
+				"INSERT INTO audio_files (id, duration, bit_rate, sample_rate, codec, channels) VALUES (?, 240, 320000, 44100, 'MP3', 2)",
+				id);
+		jdbcTemplate.update(
+				"INSERT INTO music_files (id, artist, album, track_name, track_number, genre) VALUES (?, 'Test Artist', 'Test Album', 'Test Track', 1, 'Rock')",
+				id);
+	}
+}

--- a/service/src/test/java/fi/poltsi/vempain/file/controller/files/MusicFileControllerCTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/controller/files/MusicFileControllerCTC.java
@@ -50,7 +50,11 @@ class MusicFileControllerCTC extends AbstractControllerCTC {
 					.andExpect(status().isOk())
 					.andExpect(jsonPath("$.id").value(TEST_ID))
 					.andExpect(jsonPath("$.file_type").value("MUSIC"))
-					.andExpect(jsonPath("$.artist").value("Test Artist"));
+					.andExpect(jsonPath("$.artist").value("Test Artist"))
+					.andExpect(jsonPath("$.album_artist").value("Various Artists"))
+					.andExpect(jsonPath("$.year").value(2005))
+					.andExpect(jsonPath("$.track_number").value(1))
+					.andExpect(jsonPath("$.track_total").value(12));
 		} finally {
 			deleteFileRow(TEST_ID);
 		}
@@ -91,7 +95,7 @@ class MusicFileControllerCTC extends AbstractControllerCTC {
 				"INSERT INTO audio_files (id, duration, bit_rate, sample_rate, codec, channels) VALUES (?, 240, 320000, 44100, 'MP3', 2)",
 				id);
 		jdbcTemplate.update(
-				"INSERT INTO music_files (id, artist, album, track_name, track_number, genre) VALUES (?, 'Test Artist', 'Test Album', 'Test Track', 1, 'Rock')",
+				"INSERT INTO music_files (id, artist, album_artist, album, year, track_name, track_number, track_total, genre) VALUES (?, 'Test Artist', 'Various Artists', 'Test Album', 2005, 'Test Track', 1, 12, 'Rock')",
 				id);
 	}
 }

--- a/service/src/test/java/fi/poltsi/vempain/file/service/DataServiceUTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/service/DataServiceUTC.java
@@ -235,6 +235,177 @@ class DataServiceUTC {
 	}
 
 	// -----------------------------------------------------------------------
+	// generateAndPublishGpsTimeSeriesByFileGroup — no GPS images
+	// -----------------------------------------------------------------------
+
+	@Test
+	void generateAndPublishGpsTimeSeriesByFileGroup_noGpsImages_throws404() {
+		when(imageFileRepository.findByFileGroupIdWithGpsOrderedByTime(any())).thenReturn(List.of());
+
+		assertThrows(ResponseStatusException.class,
+		             () -> dataService.generateAndPublishGpsTimeSeriesByFileGroup(1L, "test-series"));
+	}
+
+	// -----------------------------------------------------------------------
+	// generateAndPublishGpsTimeSeriesByFileGroup — invalid fileGroupId
+	// -----------------------------------------------------------------------
+
+	@Test
+	void generateAndPublishGpsTimeSeriesByFileGroup_nullFileGroupId_throws400() {
+		assertThrows(ResponseStatusException.class,
+		             () -> dataService.generateAndPublishGpsTimeSeriesByFileGroup(null, "test-series"));
+	}
+
+	@Test
+	void generateAndPublishGpsTimeSeriesByFileGroup_zeroFileGroupId_throws400() {
+		assertThrows(ResponseStatusException.class,
+		             () -> dataService.generateAndPublishGpsTimeSeriesByFileGroup(0L, "test-series"));
+	}
+
+	@Test
+	void generateAndPublishGpsTimeSeriesByFileGroup_negativeFileGroupId_throws400() {
+		assertThrows(ResponseStatusException.class,
+		             () -> dataService.generateAndPublishGpsTimeSeriesByFileGroup(-1L, "test-series"));
+	}
+
+	// -----------------------------------------------------------------------
+	// generateAndPublishGpsTimeSeriesByFileGroup — blank timeSeriesName
+	// -----------------------------------------------------------------------
+
+	@Test
+	void generateAndPublishGpsTimeSeriesByFileGroup_blankTimeSeriesName_throws400() {
+		assertThrows(ResponseStatusException.class,
+		             () -> dataService.generateAndPublishGpsTimeSeriesByFileGroup(1L, "  "));
+	}
+
+	@Test
+	void generateAndPublishGpsTimeSeriesByFileGroup_nullTimeSeriesName_throws400() {
+		assertThrows(ResponseStatusException.class,
+		             () -> dataService.generateAndPublishGpsTimeSeriesByFileGroup(1L, null));
+	}
+
+	// -----------------------------------------------------------------------
+	// generateAndPublishGpsTimeSeriesByFileGroup — happy path
+	// -----------------------------------------------------------------------
+
+	@Test
+	void generateAndPublishGpsTimeSeriesByFileGroup_publishesCorrectIdentifier() {
+		var gps = GpsLocationEntity.builder()
+		                           .latitude(new BigDecimal("60.12345"))
+		                           .latitudeRef('N')
+		                           .longitude(new BigDecimal("24.98765"))
+		                           .longitudeRef('E')
+		                           .altitude(130.0)
+		                           .build();
+
+		var image = new ImageFileEntity();
+		image.setFilename("photo.jpg");
+		image.setGpsTimestamp(Instant.parse("2024-06-01T12:00:00Z"));
+		image.setGpsLocation(gps);
+
+		when(imageFileRepository.findByFileGroupIdWithGpsOrderedByTime(42L)).thenReturn(List.of(image));
+		when(vempainAdminDataClient.getDataSetByIdentifier("holidays_2024"))
+				.thenThrow(mock(FeignException.NotFound.class));
+
+		var dataResponse = new DataResponse();
+		dataResponse.setIdentifier("holidays_2024");
+		when(vempainAdminDataClient.createDataSet(any(DataRequest.class)))
+				.thenReturn(ResponseEntity.ok(dataResponse));
+
+		var result = dataService.generateAndPublishGpsTimeSeriesByFileGroup(42L, "holidays_2024");
+
+		assertThat(result).isNotNull();
+		assertThat(result.getIdentifier()).isEqualTo("holidays_2024");
+
+		// Verify create was called with correct request fields
+		var captor = ArgumentCaptor.forClass(DataRequest.class);
+		verify(vempainAdminDataClient).createDataSet(captor.capture());
+		var req = captor.getValue();
+		assertThat(req.getIdentifier()).isEqualTo("holidays_2024");
+		assertThat(req.getType()).isEqualTo("time_series");
+		assertThat(req.getCreateSql()).startsWith("CREATE TABLE");
+		assertThat(req.getCreateSql()).contains("timestamp");
+		assertThat(req.getCreateSql()).contains("latitude");
+		assertThat(req.getCsvData()).contains("2024-06-01T12:00:00Z");
+		assertThat(req.getCsvData()).contains("60.12345");
+		assertThat(req.getCsvData()).contains("photo.jpg");
+		verify(vempainAdminDataClient).getDataSetByIdentifier("holidays_2024");
+		verify(vempainAdminDataClient, never()).updateDataSet(any(DataRequest.class));
+	}
+
+	@Test
+	void generateAndPublishGpsTimeSeriesByFileGroup_hyphenatedName_normalizesIdentifier() {
+		var gps = GpsLocationEntity.builder()
+		                           .latitude(new BigDecimal("60.12345"))
+		                           .latitudeRef('N')
+		                           .longitude(new BigDecimal("24.98765"))
+		                           .longitudeRef('E')
+		                           .altitude(130.0)
+		                           .build();
+
+		var image = new ImageFileEntity();
+		image.setFilename("photo.jpg");
+		image.setGpsTimestamp(Instant.parse("2024-06-01T12:00:00Z"));
+		image.setGpsLocation(gps);
+
+		when(imageFileRepository.findByFileGroupIdWithGpsOrderedByTime(473L)).thenReturn(List.of(image));
+		when(vempainAdminDataClient.getDataSetByIdentifier("matkailu_etiopia_2016"))
+				.thenThrow(mock(FeignException.NotFound.class));
+
+		var dataResponse = new DataResponse();
+		dataResponse.setIdentifier("matkailu_etiopia_2016");
+		when(vempainAdminDataClient.createDataSet(any(DataRequest.class)))
+				.thenReturn(ResponseEntity.ok(dataResponse));
+
+		var result = dataService.generateAndPublishGpsTimeSeriesByFileGroup(473L, "matkailu-etiopia-2016");
+
+		assertThat(result).isNotNull();
+		assertThat(result.getIdentifier()).isEqualTo("matkailu_etiopia_2016");
+		verify(vempainAdminDataClient).getDataSetByIdentifier("matkailu_etiopia_2016");
+
+		var captor = ArgumentCaptor.forClass(DataRequest.class);
+		verify(vempainAdminDataClient).createDataSet(captor.capture());
+		assertThat(captor.getValue()
+		                 .getIdentifier()).isEqualTo("matkailu_etiopia_2016");
+	}
+
+	@Test
+	void generateAndPublishGpsTimeSeriesByFileGroup_digitPrefixName_getsSafePrefix() {
+		var gps = GpsLocationEntity.builder()
+		                           .latitude(new BigDecimal("60.12345"))
+		                           .latitudeRef('N')
+		                           .longitude(new BigDecimal("24.98765"))
+		                           .longitudeRef('E')
+		                           .altitude(130.0)
+		                           .build();
+
+		var image = new ImageFileEntity();
+		image.setFilename("photo.jpg");
+		image.setGpsTimestamp(Instant.parse("2024-06-01T12:00:00Z"));
+		image.setGpsLocation(gps);
+
+		when(imageFileRepository.findByFileGroupIdWithGpsOrderedByTime(474L)).thenReturn(List.of(image));
+		when(vempainAdminDataClient.getDataSetByIdentifier("gps_timeseries_2016_trip"))
+				.thenThrow(mock(FeignException.NotFound.class));
+
+		var dataResponse = new DataResponse();
+		dataResponse.setIdentifier("gps_timeseries_2016_trip");
+		when(vempainAdminDataClient.createDataSet(any(DataRequest.class)))
+				.thenReturn(ResponseEntity.ok(dataResponse));
+
+		var result = dataService.generateAndPublishGpsTimeSeriesByFileGroup(474L, "2016-trip");
+
+		assertThat(result).isNotNull();
+		assertThat(result.getIdentifier()).isEqualTo("gps_timeseries_2016_trip");
+		verify(vempainAdminDataClient).getDataSetByIdentifier("gps_timeseries_2016_trip");
+
+		var captor = ArgumentCaptor.forClass(DataRequest.class);
+		verify(vempainAdminDataClient).createDataSet(captor.capture());
+		assertThat(captor.getValue()
+		                 .getIdentifier()).isEqualTo("gps_timeseries_2016_trip");
+	}
+
+	// -----------------------------------------------------------------------
 	// escapeCsv
 	// -----------------------------------------------------------------------
 

--- a/service/src/test/java/fi/poltsi/vempain/file/service/DataServiceUTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/service/DataServiceUTC.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.file.service;
 
+import feign.FeignException;
 import fi.poltsi.vempain.admin.api.request.DataRequest;
 import fi.poltsi.vempain.admin.api.response.DataResponse;
 import fi.poltsi.vempain.file.entity.GpsLocationEntity;
@@ -25,6 +26,8 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -53,16 +56,19 @@ class DataServiceUTC {
 	void buildMusicCsv_basicRow() {
 		var music = new MusicFileEntity();
 		music.setArtist("The Beatles");
+		music.setAlbumArtist("The Beatles");
 		music.setAlbum("Abbey Road");
+		music.setYear(1969);
 		music.setTrackNumber(1);
+		music.setTrackTotal(17);
 		music.setTrackName("Come Together");
 		music.setGenre("Rock");
 		music.setDuration(Duration.ofSeconds(259));
 
 		var csv = dataService.buildMusicCsv(List.of(music));
 
-		assertThat(csv).contains("artist,album,track_number,track_name,genre,duration_seconds");
-		assertThat(csv).contains("The Beatles,Abbey Road,1,Come Together,Rock,259");
+		assertThat(csv).contains("artist,album_artist,album,year,track_number,track_total,track_name,genre,duration_seconds");
+		assertThat(csv).contains("The Beatles,The Beatles,Abbey Road,1969,1,17,Come Together,Rock,259");
 	}
 
 	@Test
@@ -165,22 +171,22 @@ class DataServiceUTC {
 	void generateAndPublishMusicDataset_publishesCorrectIdentifier() {
 		var music = new MusicFileEntity();
 		music.setArtist("Miles Davis");
+		music.setAlbumArtist("Miles Davis");
 		music.setAlbum("Kind of Blue");
+		music.setYear(1959);
 		music.setTrackName("So What");
 		music.setTrackNumber(1);
+		music.setTrackTotal(5);
 		music.setGenre("Jazz");
 		music.setDuration(Duration.ofSeconds(565));
 
 		when(musicFileService.findAllOrdered()).thenReturn(List.of(music));
+		when(vempainAdminDataClient.getDataSetByIdentifier(DataService.MUSIC_IDENTIFIER))
+				.thenThrow(mock(FeignException.NotFound.class));
 
 		var dataResponse = new DataResponse();
 		dataResponse.setIdentifier(DataService.MUSIC_IDENTIFIER);
-		// Simulate update returning 404 (not found) and create returning a response
-		when(vempainAdminDataClient.updateDataSet(any(DataRequest.class)))
-				.thenThrow(feign.FeignException.NotFound.class);
 		when(vempainAdminDataClient.createDataSet(any(DataRequest.class)))
-				.thenReturn(ResponseEntity.ok(dataResponse));
-		when(vempainAdminDataClient.publishDataSet(DataService.MUSIC_IDENTIFIER))
 				.thenReturn(ResponseEntity.ok(dataResponse));
 
 		var result = dataService.generateAndPublishMusicDataset();
@@ -194,7 +200,16 @@ class DataServiceUTC {
 		var req = captor.getValue();
 		assertThat(req.getIdentifier()).isEqualTo(DataService.MUSIC_IDENTIFIER);
 		assertThat(req.getCreateSql()).startsWith("CREATE TABLE");
+		assertThat(req.getCreateSql()).contains("album_artist");
+		assertThat(req.getCreateSql()).contains("year");
+		assertThat(req.getCreateSql()).contains("track_total");
 		assertThat(req.getCsvData()).contains("Miles Davis");
+		assertThat(req.getCsvData()).contains("1959");
+		assertThat(req.getCsvData()).contains("album_artist");
+		assertThat(req.getCsvData()).contains("track_total");
+		verify(vempainAdminDataClient).getDataSetByIdentifier(DataService.MUSIC_IDENTIFIER);
+		verify(vempainAdminDataClient, never()).updateDataSet(any(DataRequest.class));
+		verify(vempainAdminDataClient, never()).publishDataSet(any(String.class));
 	}
 
 	// -----------------------------------------------------------------------

--- a/service/src/test/java/fi/poltsi/vempain/file/service/DataServiceUTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/service/DataServiceUTC.java
@@ -1,0 +1,245 @@
+package fi.poltsi.vempain.file.service;
+
+import fi.poltsi.vempain.admin.api.request.DataRequest;
+import fi.poltsi.vempain.admin.api.response.DataResponse;
+import fi.poltsi.vempain.file.entity.GpsLocationEntity;
+import fi.poltsi.vempain.file.entity.ImageFileEntity;
+import fi.poltsi.vempain.file.entity.MusicFileEntity;
+import fi.poltsi.vempain.file.feign.VempainAdminDataClient;
+import fi.poltsi.vempain.file.repository.files.ImageFileRepository;
+import fi.poltsi.vempain.file.service.files.MusicFileService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DataServiceUTC {
+
+	@Mock
+	private MusicFileService        musicFileService;
+	@Mock
+	private ImageFileRepository     imageFileRepository;
+	@Mock
+	private VempainAdminDataClient  vempainAdminDataClient;
+
+	private DataService dataService;
+
+	@BeforeEach
+	void setUp() {
+		dataService = new DataService(musicFileService, imageFileRepository, vempainAdminDataClient);
+	}
+
+	// -----------------------------------------------------------------------
+	// buildMusicCsv
+	// -----------------------------------------------------------------------
+
+	@Test
+	void buildMusicCsv_basicRow() {
+		var music = new MusicFileEntity();
+		music.setArtist("The Beatles");
+		music.setAlbum("Abbey Road");
+		music.setTrackNumber(1);
+		music.setTrackName("Come Together");
+		music.setGenre("Rock");
+		music.setDuration(Duration.ofSeconds(259));
+
+		var csv = dataService.buildMusicCsv(List.of(music));
+
+		assertThat(csv).contains("artist,album,track_number,track_name,genre,duration_seconds");
+		assertThat(csv).contains("The Beatles,Abbey Road,1,Come Together,Rock,259");
+	}
+
+	@Test
+	void buildMusicCsv_nullFields_producesEmptyColumns() {
+		var music = new MusicFileEntity();
+		// All fields null / default
+
+		var csv = dataService.buildMusicCsv(List.of(music));
+
+		// Should still have header + data row with empty values
+		assertThat(csv).startsWith("artist,album");
+		var lines = csv.split("\n");
+		assertThat(lines).hasSize(2); // header + one data row
+	}
+
+	@Test
+	void buildMusicCsv_specialCharactersEscaped() {
+		var music = new MusicFileEntity();
+		music.setArtist("Guns N' Roses");
+		music.setAlbum("\"Appetite for Destruction\"");
+		music.setTrackName("Welcome to the Jungle");
+
+		var csv = dataService.buildMusicCsv(List.of(music));
+
+		assertThat(csv).contains("Guns N' Roses");
+		// The album has double-quotes so it should be wrapped
+		assertThat(csv).contains("\"\"\"Appetite for Destruction\"\"\"");
+	}
+
+	// -----------------------------------------------------------------------
+	// buildGpsIdentifier
+	// -----------------------------------------------------------------------
+
+	@Test
+	void buildGpsIdentifier_simpleDir() {
+		var id = dataService.buildGpsIdentifier("/holidays/2024");
+		assertThat(id).startsWith(DataService.GPS_IDENTIFIER_PREFIX);
+		assertThat(id).matches("^[a-z][a-z0-9_]*$");
+	}
+
+	@Test
+	void buildGpsIdentifier_rootDir() {
+		var id = dataService.buildGpsIdentifier("/");
+		assertThat(id).startsWith(DataService.GPS_IDENTIFIER_PREFIX);
+		assertThat(id).matches("^[a-z][a-z0-9_]*$");
+	}
+
+	@Test
+	void buildGpsIdentifier_specialCharsReplaced() {
+		var id = dataService.buildGpsIdentifier("/my photos/2024 trip");
+		assertThat(id).doesNotContain(" ");
+		assertThat(id).matches("^[a-z][a-z0-9_]*$");
+	}
+
+	// -----------------------------------------------------------------------
+	// buildGpsCsv
+	// -----------------------------------------------------------------------
+
+	@Test
+	void buildGpsCsv_withGpsData() {
+		var gps = GpsLocationEntity.builder()
+								   .latitude(new BigDecimal("60.12345"))
+								   .latitudeRef('N')
+								   .longitude(new BigDecimal("24.98765"))
+								   .longitudeRef('E')
+								   .altitude(130.0)
+								   .build();
+
+		var image = new ImageFileEntity();
+		image.setFilename("photo.jpg");
+		image.setGpsTimestamp(Instant.parse("2024-06-01T12:00:00Z"));
+		image.setGpsLocation(gps);
+
+		var csv = dataService.buildGpsCsv(List.of(image));
+
+		assertThat(csv).contains("timestamp,latitude");
+		assertThat(csv).contains("2024-06-01T12:00:00Z");
+		assertThat(csv).contains("60.12345");
+		assertThat(csv).contains("N");
+		assertThat(csv).contains("photo.jpg");
+	}
+
+	// -----------------------------------------------------------------------
+	// generateAndPublishMusicDataset — no music files
+	// -----------------------------------------------------------------------
+
+	@Test
+	void generateAndPublishMusicDataset_noMusicFiles_throws404() {
+		when(musicFileService.findAllOrdered()).thenReturn(List.of());
+
+		assertThrows(ResponseStatusException.class,
+					 () -> dataService.generateAndPublishMusicDataset());
+	}
+
+	// -----------------------------------------------------------------------
+	// generateAndPublishMusicDataset — happy path
+	// -----------------------------------------------------------------------
+
+	@Test
+	void generateAndPublishMusicDataset_publishesCorrectIdentifier() {
+		var music = new MusicFileEntity();
+		music.setArtist("Miles Davis");
+		music.setAlbum("Kind of Blue");
+		music.setTrackName("So What");
+		music.setTrackNumber(1);
+		music.setGenre("Jazz");
+		music.setDuration(Duration.ofSeconds(565));
+
+		when(musicFileService.findAllOrdered()).thenReturn(List.of(music));
+
+		var dataResponse = new DataResponse();
+		dataResponse.setIdentifier(DataService.MUSIC_IDENTIFIER);
+		// Simulate update returning 404 (not found) and create returning a response
+		when(vempainAdminDataClient.updateDataSet(any(DataRequest.class)))
+				.thenThrow(feign.FeignException.NotFound.class);
+		when(vempainAdminDataClient.createDataSet(any(DataRequest.class)))
+				.thenReturn(ResponseEntity.ok(dataResponse));
+		when(vempainAdminDataClient.publishDataSet(DataService.MUSIC_IDENTIFIER))
+				.thenReturn(ResponseEntity.ok(dataResponse));
+
+		var result = dataService.generateAndPublishMusicDataset();
+
+		assertThat(result).isNotNull();
+		assertThat(result.getIdentifier()).isEqualTo(DataService.MUSIC_IDENTIFIER);
+
+		// Verify create was called with correct request fields
+		var captor = ArgumentCaptor.forClass(DataRequest.class);
+		verify(vempainAdminDataClient).createDataSet(captor.capture());
+		var req = captor.getValue();
+		assertThat(req.getIdentifier()).isEqualTo(DataService.MUSIC_IDENTIFIER);
+		assertThat(req.getCreateSql()).startsWith("CREATE TABLE");
+		assertThat(req.getCsvData()).contains("Miles Davis");
+	}
+
+	// -----------------------------------------------------------------------
+	// generateAndPublishGpsTimeSeries — no GPS images
+	// -----------------------------------------------------------------------
+
+	@Test
+	void generateAndPublishGpsTimeSeries_noGpsImages_throws404() {
+		when(imageFileRepository.findByFilePathWithGpsOrderedByTime(any())).thenReturn(List.of());
+
+		assertThrows(ResponseStatusException.class,
+					 () -> dataService.generateAndPublishGpsTimeSeries("/some/path"));
+	}
+
+	// -----------------------------------------------------------------------
+	// generateAndPublishGpsTimeSeries — blank path
+	// -----------------------------------------------------------------------
+
+	@Test
+	void generateAndPublishGpsTimeSeries_blankPath_throws400() {
+		assertThrows(ResponseStatusException.class,
+					 () -> dataService.generateAndPublishGpsTimeSeries("  "));
+	}
+
+	// -----------------------------------------------------------------------
+	// escapeCsv
+	// -----------------------------------------------------------------------
+
+	@Test
+	void escapeCsv_nullReturnsEmpty() {
+		assertThat(DataService.escapeCsv(null)).isEmpty();
+	}
+
+	@Test
+	void escapeCsv_noSpecialChars_unchanged() {
+		assertThat(DataService.escapeCsv("hello world")).isEqualTo("hello world");
+	}
+
+	@Test
+	void escapeCsv_commaWrapped() {
+		assertThat(DataService.escapeCsv("a,b")).isEqualTo("\"a,b\"");
+	}
+
+	@Test
+	void escapeCsv_quoteDoubled() {
+		assertThat(DataService.escapeCsv("say \"hi\"")).isEqualTo("\"say \"\"hi\"\"\"");
+	}
+}

--- a/service/src/test/java/fi/poltsi/vempain/file/service/LocationServiceITC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/service/LocationServiceITC.java
@@ -9,7 +9,6 @@ import fi.poltsi.vempain.file.entity.GpsLocationEntity;
 import fi.poltsi.vempain.file.entity.LocationGuardEntity;
 import fi.poltsi.vempain.file.repository.LocationGuardRepository;
 import fi.poltsi.vempain.file.repository.LocationRepository;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -40,7 +39,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-@Slf4j
 @ExtendWith(MockitoExtension.class)
 class LocationServiceITC {
 
@@ -391,7 +389,6 @@ class LocationServiceITC {
 			var offsetLatitude    = centerLat + latOffsetDeg;
 			var offsetLongitude   = centerLon + lonOffsetDeg;
 			var gpsLocationEntity = gps(offsetLatitude, offsetLongitude);
-			log.info("Check distance between center ({}, {}) and test point ({}, {})", centerLat, centerLon, offsetLatitude, offsetLongitude);
 
 			assertEquals(expectedInside, locationService.isGuardedLocation(gpsLocationEntity));
 		}

--- a/service/src/test/java/fi/poltsi/vempain/file/tools/MetadataToolUTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/tools/MetadataToolUTC.java
@@ -1,18 +1,17 @@
 package fi.poltsi.vempain.file.tools;
 
-import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import java.math.BigDecimal;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Slf4j
 class MetadataToolUTC {
 
 	private static final double DELTA = 1e-6;
@@ -141,7 +140,6 @@ class MetadataToolUTC {
 			root.put("GPS", gpsObj);
 		}
 
-		log.info("Scenario {}: input JSON: {}", scenario, root.toString());
 		var entity = MetadataTool.extractGpsData(root);
 
 		if (expectedLat == null) {
@@ -190,7 +188,6 @@ class MetadataToolUTC {
 	 * but accepts a string directly instead of requiring a file.
 	 */
 	private double parseDurationStringHelper(String durationStr) {
-		log.info("Parsing duration string: '{}'", durationStr);
 		// If the string is empty or null, return 0
 		if (durationStr == null || durationStr.isBlank()) {
 			return 0.0;
@@ -230,6 +227,166 @@ class MetadataToolUTC {
 
 			// It's already in seconds format (possibly with decimal)
 			return Double.parseDouble(durationStr);
+		}
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"0:04:17,257",
+			"0:02:50 (approx),170",
+			"24.47 s,24.47",
+			"42.5,42.5",
+			"100:00:00,99999",
+			"'',0"
+	})
+	void durationFromString_handlesExifVariants(String input, double expectedSeconds) {
+		var duration = MetadataTool.durationFromString(input);
+		assertEquals(expectedSeconds, duration.toMillis() / 1000.0, DELTA);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"[{\"AudioBitrate\":\"280 kbps\"}], 0, 280",
+			"[{\"AvgBitrate\":\"764 kbps\"}], 0, 764",
+			"[{\"NominalBitrate\":\"1.4 Mbps\"}], 0, 1400",
+			"[{\"Duration\":\"0:04:17\"}], 32000000, 996"
+	})
+	void parseAudioBitRateKbps_usesFallbacks(String output, long fileSize, int expected) {
+		assertEquals(expected, MetadataTool.parseAudioBitRateKbps(output, fileSize));
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"ID3,Artist,Motorhead,artist",
+			"ID3,Band,Various Artists,album_artist",
+			"ID3,Year,2005,year",
+			"ID3,Track,03/03,track_total",
+			"Vorbis,Album,Uurnapolyjen Paluu,album",
+			"Vorbis,Albumartist,Sur-Rur,album_artist",
+			"Vorbis,Date,2007,year",
+			"Vorbis,Title,Maisema,title",
+			"Vorbis,TrackNumber,03,track",
+			"Vorbis,Tracktotal,10,track_total",
+			"Vorbis,Genre,Punk Rock,genre",
+			"ROOT,Artist,Sur-Rur,artist"
+	})
+	void musicExtraction_handlesGroupedAndFlatMetadata(String group, String key, String value, String expectedField) {
+		var root = new JSONObject();
+		if ("ROOT".equals(group)) {
+			root.put(key, value);
+		} else {
+			root.put(group, new JSONObject().put(key, value));
+		}
+
+		switch (expectedField) {
+			case "artist" -> assertEquals(value, MetadataTool.extractMusicArtist(root));
+			case "album_artist" -> assertEquals(value, MetadataTool.extractMusicAlbumArtist(root));
+			case "album" -> assertEquals(value, MetadataTool.extractMusicAlbum(root));
+			case "year" -> assertEquals(Integer.parseInt(value), MetadataTool.extractMusicYear(root));
+			case "title" -> assertEquals(value, MetadataTool.extractMusicTitle(root));
+			case "track" -> assertEquals(Integer.parseInt(value), MetadataTool.extractMusicTrackNumber(root));
+			case "track_total" -> {
+				int expectedTotal = value.contains("/") ? Integer.parseInt(value.split("/")[1]) : Integer.parseInt(value);
+				assertEquals(expectedTotal, MetadataTool.extractMusicTrackTotal(root));
+			}
+			case "genre" -> assertEquals(value, MetadataTool.extractMusicGenre(root));
+			default -> throw new IllegalArgumentException("Unexpected field: " + expectedField);
+		}
+	}
+
+	@ParameterizedTest
+	@CsvSource(value = {
+			"03/10,3",
+			"Track 7,7",
+			"'',0",
+			"abc,0"
+	})
+	void extractMusicTrackNumber_parsesCommonFormats(String input, Integer expected) {
+		var root = new JSONObject().put("Vorbis", new JSONObject().put("TrackNumber", input));
+		assertEquals(expected, MetadataTool.extractMusicTrackNumber(root));
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"10,10",
+			"0,0"
+	})
+	void extractMusicTrackNumber_handlesNumericJsonValues(int input, int expected) {
+		var root = new JSONObject().put("Vorbis", new JSONObject().put("TrackNumber", input));
+		assertEquals(expected, MetadataTool.extractMusicTrackNumber(root));
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"TrackNumber,10,10",
+			"Tracknumber,11,11"
+	})
+	void extractMusicTrackNumber_supportsFlatAndVariantKeys(String key, int input, int expected) {
+		var root = new JSONObject().put(key, input);
+		assertEquals(expected, MetadataTool.extractMusicTrackNumber(root));
+	}
+
+	@ParameterizedTest
+	@CsvSource(value = {
+			"03/10,10",
+			"Tracktotal 12,12",
+			"'',0",
+			"abc,0"
+	})
+	void extractMusicTrackTotal_parsesCommonFormats(String input, Integer expected) {
+		var root = new JSONObject().put("ID3", new JSONObject().put("Track", input));
+		assertEquals(expected, MetadataTool.extractMusicTrackTotal(root));
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"10,10",
+			"0,0"
+	})
+	void extractMusicTrackTotal_handlesNumericJsonValues(int input, int expected) {
+		var root = new JSONObject().put("Vorbis", new JSONObject().put("Tracktotal", input));
+		assertEquals(expected, MetadataTool.extractMusicTrackTotal(root));
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"2005,2005",
+			"2005-11-19,2005",
+			"'',0",
+			"unknown,0"
+	})
+	void extractMusicYear_parsesYearFromCommonFormats(String input, Integer expected) {
+		var root = new JSONObject().put("Vorbis", new JSONObject().put("Date", input));
+		assertEquals(expected, MetadataTool.extractMusicYear(root));
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"Band,Various Artists",
+			"Artist,Bombers",
+			"Albumartist,Sur-Rur"
+	})
+	void extractMusicAlbumArtist_supportsDifferentTagNames(String key, String expected) {
+		var group = "Albumartist".equals(key) ? "Vorbis" : "ID3";
+		var root  = new JSONObject().put(group, new JSONObject().put(key, expected));
+		assertEquals(expected, MetadataTool.extractMusicAlbumArtist(root));
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"Artist,yes",
+			"Title,yes",
+			"Album,yes",
+			"Genre,yes",
+			"Comment,no"
+	})
+	void hasMusicMetadata_detectsGenreAlso(String key, String expectedYesNo) {
+		var vorbis = new JSONObject().put(key, "X");
+		var root   = new JSONObject().put("Vorbis", vorbis);
+		if ("yes".equals(expectedYesNo)) {
+			assertTrue(MetadataTool.hasMusicMetadata(root));
+		} else {
+			assertFalse(MetadataTool.hasMusicMetadata(root));
 		}
 	}
 }


### PR DESCRIPTION
This pull request introduces comprehensive support for music file management and CSV dataset publication, as well as improvements to GPS time-series dataset handling. It adds new APIs, entities, and documentation for managing music files (with rich metadata) and for publishing datasets to the Vempain Admin backend. There are also dependency updates and improvements to duration handling for audio files.

**Music File Management and Dataset Publication:**

- Added a new `MusicFileEntity` type (as a subtype of `AudioFileEntity`) for files with music metadata, along with a corresponding `MusicFileResponse` DTO and APIs for listing, retrieving, and deleting music files. [[1]](diffhunk://#diff-d00743dc4e878f258330deadcd4008e361276d760b58b672150c54bb1ac9758aR68-R138) [[2]](diffhunk://#diff-8df85aebb06f26cac976509068bd37432be3166a1a7182fc61007eedbd70e07aR1-R41) [[3]](diffhunk://#diff-02d8ec952c60bf7d450a79f76f097400636565f3b85041e60df6d25ef4c38489R1-R59) [[4]](diffhunk://#diff-f141fc817aa50342cba5999fcee272ddb0fc978c015b5e7a2d906e776ca15af8R1-R40) [[5]](diffhunk://#diff-c6c1ac547bc6f93146408b7f566a6826c6ee5eb935df462aeb9978c3a81c0c7dR16)
- Introduced a new endpoint (`POST /api/data-publish/music`) to generate and publish a music library CSV dataset to the Vempain Admin backend. [[1]](diffhunk://#diff-d00743dc4e878f258330deadcd4008e361276d760b58b672150c54bb1ac9758aR68-R138) [[2]](diffhunk://#diff-5abcb91228f88cbdea7d59722b5d103b6655004934f70d58cfac8faeae8ab02bR1-R56) [[3]](diffhunk://#diff-c9fccbe5ab204bf38ed39ce39c0dbf4d82f65e4ccb54d2c46d495282658ebd8eR1-R28)

**GPS Time-Series Dataset Publication:**

- Enhanced the GPS dataset publication flow by supporting both directory-path and file-group-based publication, with a new request DTO and updated documentation. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R64-R72) [[2]](diffhunk://#diff-6f96d43f66ad67a6fc97a6e0bd52e40d37d94b047087fdcf9a409bf8a449d670R1-R29) [[3]](diffhunk://#diff-5abcb91228f88cbdea7d59722b5d103b6655004934f70d58cfac8faeae8ab02bR1-R56) [[4]](diffhunk://#diff-c9fccbe5ab204bf38ed39ce39c0dbf4d82f65e4ccb54d2c46d495282658ebd8eR1-R28) [[5]](diffhunk://#diff-d00743dc4e878f258330deadcd4008e361276d760b58b672150c54bb1ac9758aR68-R138)

**Persistence and Data Handling Improvements:**

- Implemented a `DurationSecondsConverter` to persist audio durations as whole seconds, ensuring compatibility with the schema and preventing numeric overflow. [[1]](diffhunk://#diff-af86f73fa175ee155b1d0cf2bed7ab5ce387acfd8d7e9766506dce7e75f3b242R5) [[2]](diffhunk://#diff-af86f73fa175ee155b1d0cf2bed7ab5ce387acfd8d7e9766506dce7e75f3b242R28) [[3]](diffhunk://#diff-95e79f2911c3c20a6203ba1eb9cbd1cd92c0bcae7fd79a6696695c1f65972ecaR1-R39)

**Dependency and Version Updates:**

- Updated dependencies for Swagger, Springdoc, and Vempain Admin/Auth API versions to ensure compatibility with new features. [[1]](diffhunk://#diff-25d49275b34eb312234a2e92eaef61ca1e0a324f9f534cdf8d5e24b51135c3c6R44) [[2]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L18-R26)

**Documentation:**

- Extended `AGENTS.md` with detailed explanations of music file handling, CSV dataset generation, endpoint usage, and data publication logic.