### PR TITLE
Use shared workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,5 @@
 name: CI
+
 on:
   pull_request:
     branches:
@@ -9,182 +10,14 @@ on:
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
 
-env:
-  REGISTRY: ghcr.io
-  REGISTRY_NAMESPACE: vempain
-  IMAGE_NAME: ${{ github.repository }}
-
-concurrency: build
+permissions:
+  contents: write
+  packages: write
+  id-token: write
 
 jobs:
-  test:
-    name: Run all tests
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_ACTOR: ${{ github.actor }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    permissions:
-      contents: read
-      packages: read
-
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v6
-
-      - name: Set up Java temurin 25
-        uses: actions/setup-java@v5
-        with:
-          java-version: '25'
-          distribution: 'temurin'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
-        with:
-          cache-read-only: false
-
-      - name: Install exifdata for test setup
-        run: sudo apt-get install -y exiftool
-
-      - name: Run tests with Gradle
-        run: ./gradlew clean test
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v7
-        if: success() || failure()
-        with:
-          name: test-results
-          path: service/build/reports
-          retention-days: 2
-          compression-level: 9
-          overwrite: true
-          if-no-files-found: warn
-
-  build-docker:
-    name: Build and push Docker image
-    needs: test
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
-    env:
-      GITHUB_ACTOR: ${{ github.actor }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    permissions:
-      contents: write
-      packages: write
-      id-token: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Get main and base version
-        id: basemain
-        shell: bash
-        run: |
-          baseVersion=$(cat VERSION)
-          mainVersion=$(echo ${baseVersion} | cut -d '.' -f 1)
-          echo "baseVersion=${baseVersion}" >> $GITHUB_OUTPUT
-          echo "mainVersion=${mainVersion}" >> $GITHUB_OUTPUT
-
-      - name: Generate new version
-        id: newVer
-        shell: bash
-        run: |
-          git fetch --tags origin
-          currentVersion=$(git tag --list --sort=-version:refname "${baseVersion}.*" | head -n 1 || "${baseVersion}.0")
-
-          if [ -z "${currentVersion}" ]; then
-            newVersion="${baseVersion}.0"
-          else
-            runningNumber=$(echo ${currentVersion} | cut -f 3 -d '.')
-            newVersion="${baseVersion}.$((${runningNumber} + 1))"
-          fi
-          echo "The generated new version is: ${newVersion}"
-          echo "newVersion=${newVersion}" >> $GITHUB_OUTPUT
-        env:
-          baseVersion: ${{ steps.basemain.outputs.baseVersion }}
-
-      - name: Set up Java temurin 25
-        uses: actions/setup-java@v5
-        with:
-          java-version: '25'
-          distribution: 'temurin'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
-        with:
-          cache-read-only: false
-
-      - name: Build jar-file with Gradle
-        shell: bash
-        run: ./gradlew clean bootJar -Pversion=${newVersion}
-        env:
-          newVersion: ${{ steps.newVer.outputs.newVersion }}
-
-      - name: Publish API to GitHub Packages (Maven)
-        if: contains(github.event.head_commit.message, 'Merge pull request')
-        run: ./gradlew :api:clean :api:publish -PreleaseVersion=${newVersion}
-        env:
-          newVersion: ${{ steps.newVer.outputs.newVersion }}
-
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
-      - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push Docker image to registry
-        shell: bash
-        run: |
-          imgName="${{ env.REGISTRY }}/${{ env.REGISTRY_NAMESPACE }}/$(echo "${{ env.IMAGE_NAME }}" | tr '[:upper:]' '[:lower:]')"
-          docker build . --tag ${imgName}:latest
-          echo "Setting versions to: '${mainVersion}', '${baseVersion}', '${newVersion}'"
-          docker image tag ${imgName}:latest ${imgName}:${mainVersion}
-          docker image tag ${imgName}:latest ${imgName}:${baseVersion}
-          docker image tag ${imgName}:latest ${imgName}:${newVersion}
-          docker push --all-tags ${imgName}
-        env:
-          mainVersion: ${{ steps.basemain.outputs.mainVersion }}
-          baseVersion: ${{ steps.basemain.outputs.baseVersion }}
-          newVersion: ${{ steps.newVer.outputs.newVersion }}
-
-      - name: Create tag
-        uses: actions/github-script@v9
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: 'refs/tags/${{ steps.newVer.outputs.newVersion }}',
-              sha: context.sha
-            })
-
-      - name: Create GitHub Release
-        uses: actions/github-script@v9
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const tag = '${{ steps.newVer.outputs.newVersion }}';
-            const resp = await github.rest.repos.createRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag_name: tag,
-              name: `Release ${tag}`,
-              body: `Automated release for ${tag}
-
-              Docker tags pushed:
-              - latest
-              - ${{ steps.basemain.outputs.mainVersion }}
-              - ${{ steps.basemain.outputs.baseVersion }}
-              - ${tag}
-              `,
-              draft: false,
-              prerelease: false,
-              generate_release_notes: true
-            });
-            core.info(`Release created: ${resp.data.html_url}`);
+  ci:
+    uses: Vempain/vempain-workflows/.github/workflows/spring-boot-service.yaml@main
+    with:
+      install_exiftool: true
+    secrets: inherit


### PR DESCRIPTION
This pull request significantly refactors the CI workflow configuration by replacing the custom, in-repo GitHub Actions logic with a reusable workflow from an external repository. This change centralizes and simplifies the CI/CD process, reducing maintenance and ensuring consistency with other projects using the same workflow.

Key changes include:

**CI/CD Workflow Refactoring:**

* The entire custom workflow logic in `.github/workflows/ci.yaml` has been removed, including all steps for testing, building, versioning, publishing, Docker image creation, and release management. Instead, the workflow now references `Vempain/vempain-workflows/.github/workflows/spring-boot-service.yaml@main` as a reusable workflow, passing in the necessary parameters and secrets.

**Configuration Simplification:**

* The workflow file is now much shorter and easier to maintain, as all job definitions, environment variables, and build logic are handled externally. Only minimal configuration (such as `install_exiftool: true`) is specified in the local workflow file.

**Workflow Trigger Update:**

* The workflow trigger section was slightly adjusted to ensure the workflow is activated on pull requests and relevant branches.