### PR TITLE
Bump Gradlew and dependencies to latest version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 releaseVersion=0.0.1-SNAPSHOT
 javaVersion=25
 # https://mvnrepository.com/artifact/org.springframework.boot/spring-boot
-springBootVersion=4.0.5
+springBootVersion=4.0.6
 # https://mvnrepository.com/artifact/org.testcontainers/testcontainers
-testContainersVersion=2.0.4
+testContainersVersion=2.0.5
 # https://mvnrepository.com/artifact/io.freefair.lombok/io.freefair.lombok.gradle.plugin
 ioFreeFairLombok=9.2.0
 # https://mvnrepository.com/artifact/org.json/json
@@ -21,6 +21,6 @@ springdocVersion=3.0.3
 # https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter
 mockitoVersion=5.23.0
 # https://github.com/Vempain/vempain-auth/packages/2723219
-vempainAuthVersion=1.0.8
+vempainAuthVersion=1.0.10
 # https://github.com/Vempain/vempain-admin-backend/packages/2624185
-vempainAdminVersion=1.0.18
+vempainAdminVersion=1.0.21

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This pull request updates several dependencies and tools to their latest versions to ensure improved stability, security, and compatibility across the project.

Dependency and tool version upgrades:

**Build tool updates:**
* Upgraded Gradle wrapper from version 9.4.1 to 9.5.0 in `gradle-wrapper.properties` for improved build performance and compatibility.

**Dependency updates:**
* Updated `springBootVersion` from 4.0.5 to 4.0.6 and `testContainersVersion` from 2.0.4 to 2.0.5 in `gradle.properties` to incorporate the latest bug fixes and features.
* Updated internal package versions: `vempainAuthVersion` from 1.0.8 to 1.0.10 and `vempainAdminVersion` from 1.0.18 to 1.0.21 in `gradle.properties` for better integration and latest changes from those packages.