### PR TITLE
Move all versions to gradle.properties

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -86,7 +86,7 @@ publishing {
 }
 
 jacoco {
-	toolVersion = "0.8.13"
+	toolVersion = "${jacocoVersion}"
 }
 
 tasks.named('test') {

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,19 @@ mockitoVersion=5.23.0
 vempainAuthVersion=1.0.10
 # https://github.com/Vempain/vempain-admin-backend/packages/2624185
 vempainAdminVersion=1.0.21
+# https://mvnrepository.com/artifact/commons-codec/commons-codec
+commonsCodecVersion=1.21.0
+# https://mvnrepository.com/artifact/jakarta.xml.bind/jakarta.xml.bind-api
+jakartaBindApiVersion=4.0.5
+# https://mvnrepository.com/artifact/jakarta.annotation/jakarta.annotation-api
+jakartaAnnotationApiVersion=3.0.0
+# https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-starter-openfeign
+springCloudStarterOpenfeignVersion=5.0.1
+# https://mvnrepository.com/artifact/net.coobird/thumbnailator
+thumbnailatorVersion=0.4.21
+# https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-dependencies
+springCloudVersion=2025.1.1
+# https://mvnrepository.com/artifact/io.spring.gradle/dependency-management-plugin
+gradleSpringPluginVersion=1.1.7
+# https://mvnrepository.com/artifact/org.jacoco/jacoco
+jacocoVersion=0.8.14

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -4,7 +4,7 @@ plugins {
 	id 'application'
 	id 'org.springframework.boot' version "${springBootVersion}"
 	id "io.freefair.lombok" version "${ioFreeFairLombok}"
-	id 'io.spring.dependency-management' version '1.1.7'
+	id 'io.spring.dependency-management' version "${gradleSpringPluginVersion}"
 	id 'jacoco'
 }
 
@@ -63,19 +63,13 @@ dependencies {
 	implementation "org.springframework.boot:spring-boot-starter-validation:${springBootVersion}"
 	developmentOnly "org.springframework.boot:spring-boot-docker-compose:${springBootVersion}"
 	implementation "io.jsonwebtoken:jjwt-api:${jjwtVersion}"
-	// https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui
 	implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:${springdocVersion}"
-	// https://mvnrepository.com/artifact/jakarta.xml.bind/jakarta.xml.bind-api
-	implementation "jakarta.xml.bind:jakarta.xml.bind-api:4.0.5"
-	// https://mvnrepository.com/artifact/jakarta.annotation/jakarta.annotation-api
-	implementation "jakarta.annotation:jakarta.annotation-api:3.0.0"
-	// https://mvnrepository.com/artifact/commons-codec/commons-codec
-	implementation "commons-codec:commons-codec:1.21.0"
+	implementation "jakarta.xml.bind:jakarta.xml.bind-api:${jakartaBindApiVersion}"
+	implementation "jakarta.annotation:jakarta.annotation-api:${jakartaAnnotationApiVersion}"
+	implementation "commons-codec:commons-codec:${commonsCodecVersion}"
 	implementation "org.json:json:${jsonVersion}"
-	// https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-starter-openfeign
-	implementation "org.springframework.cloud:spring-cloud-starter-openfeign:5.0.1"
-	// https://mvnrepository.com/artifact/net.coobird/thumbnailator
-	implementation "net.coobird:thumbnailator:0.4.21"
+	implementation "org.springframework.cloud:spring-cloud-starter-openfeign:${springCloudStarterOpenfeignVersion}"
+	implementation "net.coobird:thumbnailator:${thumbnailatorVersion}"
 	runtimeOnly "io.jsonwebtoken:jjwt-impl:${jjwtVersion}"
 	runtimeOnly "io.jsonwebtoken:jjwt-jackson:${jjwtVersion}"
 	runtimeOnly "org.postgresql:postgresql:${postgresqlVersion}"
@@ -92,8 +86,7 @@ dependencies {
 
 dependencyManagement {
 	imports {
-		// https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-dependencies
-		mavenBom "org.springframework.cloud:spring-cloud-dependencies:2025.1.1"
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:$springCloudVersion"
 	}
 }
 


### PR DESCRIPTION
This pull request updates the way dependency versions are managed in the Gradle build files by moving hardcoded version numbers into the `gradle.properties` file and referencing them via variables. This change centralizes version management, making it easier to update dependencies in the future and improving maintainability. Additionally, it updates some dependencies to use the latest versions.

Dependency version management improvements:

* Moved hardcoded dependency versions for `commons-codec`, `jakarta.xml.bind-api`, `jakarta.annotation-api`, `spring-cloud-starter-openfeign`, `thumbnailator`, `spring-cloud-dependencies`, `dependency-management-plugin`, and `jacoco` into `gradle.properties` as variables.
* Updated `service/build.gradle` and `api/build.gradle` to reference these new variables instead of hardcoded version strings for the affected dependencies and plugins. [[1]](diffhunk://#diff-7af75b543199dde7b73517b9d67651db7f9208dbe566d9d725fd96bdb4a1f445L7-R7) [[2]](diffhunk://#diff-7af75b543199dde7b73517b9d67651db7f9208dbe566d9d725fd96bdb4a1f445L66-R72) [[3]](diffhunk://#diff-7af75b543199dde7b73517b9d67651db7f9208dbe566d9d725fd96bdb4a1f445L95-R89) [[4]](diffhunk://#diff-25d49275b34eb312234a2e92eaef61ca1e0a324f9f534cdf8d5e24b51135c3c6L89-R89)

Dependency updates:

* Bumped `jacoco` version from `0.8.13` to `0.8.14`. [[1]](diffhunk://#diff-25d49275b34eb312234a2e92eaef61ca1e0a324f9f534cdf8d5e24b51135c3c6L89-R89) [[2]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19R27-R42)
* Ensured all affected dependencies and plugins now use the latest versions as defined in `gradle.properties`. [[1]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19R27-R42) [[2]](diffhunk://#diff-7af75b543199dde7b73517b9d67651db7f9208dbe566d9d725fd96bdb4a1f445L66-R72)