### PR TITLE
Add indexes on foreign key columns

### DIFF
--- a/service/src/main/java/fi/poltsi/vempain/file/tools/MetadataTool.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/tools/MetadataTool.java
@@ -1391,7 +1391,11 @@ public class MetadataTool {
 
 		var formatter = new DateTimeFormatterBuilder()
 				// Date
-				.appendPattern("yyyy:MM:dd HH:mm:ss")
+				.appendPattern("yyyy:MM:dd HH:mm")
+				// Optional seconds
+				.optionalStart()
+				.appendPattern(":ss")
+				.optionalEnd()
 				// Optional fractional seconds (from 1 to 9 digits)
 				.optionalStart()
 				.appendFraction(ChronoField.NANO_OF_SECOND, 1, 9, true)

--- a/service/src/main/resources/db/migration/V1003__fk_indexes_for_cascade_paths.sql
+++ b/service/src/main/resources/db/migration/V1003__fk_indexes_for_cascade_paths.sql
@@ -1,0 +1,8 @@
+-- Add missing indexes on foreign keys used in cascade paths.
+-- These improve delete performance when removing parent rows from files/tags.
+
+CREATE INDEX idx_file_group_files_file_id ON file_group_files (file_id);
+CREATE INDEX idx_metadata_file_id ON metadata (file_id);
+CREATE INDEX idx_export_files_file_id ON export_files (file_id);
+CREATE INDEX idx_file_tags_tag_id ON file_tags (tag_id);
+

--- a/service/src/test/java/fi/poltsi/vempain/file/tools/MetadataToolUTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/tools/MetadataToolUTC.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -21,11 +22,20 @@ class MetadataToolUTC {
 			"2006:11:19 00:04:34+02:00",
 			"2008:03:20 21:14:46.00+02:00",
 			"2014:06:24 09:34:01.761+03:00",
-			"2022:07:07 17:35:12.1Z"
+			"2022:07:07 17:35:12.1Z",
+			"2016:10:27 04:50+02:00"
 	})
 	void dateTimeParser(String dateTimeString) {
 		var dateTime = MetadataTool.dateTimeParser(dateTimeString);
 		assertNotNull(dateTime);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"2016:10:27 04:50+02:00,2016-10-27T02:50:00Z"
+	})
+	void dateTimeParser_parsesWithoutSeconds(String input, String expectedUtc) {
+		assertEquals(Instant.parse(expectedUtc), MetadataTool.dateTimeParser(input));
 	}
 
 	@ParameterizedTest


### PR DESCRIPTION
This pull request focuses on improving date/time parsing robustness and database performance. The main changes include making the date/time parser more flexible to handle timestamps without seconds, adding corresponding tests, and introducing new indexes to improve database operations involving foreign keys.

**Date/Time Parsing Improvements:**

* Modified the `dateTimeParser` method in `MetadataTool.java` to support parsing date/time strings that may omit seconds, making the seconds field optional.
* Added new parameterized tests in `MetadataToolUTC.java` to verify correct parsing of timestamps both with and without seconds, including a specific test for parsing without seconds.
* Imported `java.time.Instant` in the test file to support new test assertions.

**Database Performance Enhancements:**

* Added a migration script `V1003__fk_indexes_for_cascade_paths.sql` to create missing indexes on foreign key columns used in cascade paths, improving delete performance for related tables.