### PR TITLE
Add cli module

### DIFF
--- a/.github/workflows/rpm-cli.yaml
+++ b/.github/workflows/rpm-cli.yaml
@@ -1,0 +1,26 @@
+name: CLI RPM Package
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  rpm:
+    uses: Vempain/vempain-workflows/.github/workflows/rpm-cli-package.yaml@main
+    with:
+      version_file: 'VERSION'
+      gradle_task: ':cli:fatJar'
+      jar_path: 'cli/build/libs/vf-cli.jar'
+      spec_file: 'packaging/rpm/vempain-file-cli.spec'
+      source_jar_path: 'packaging/rpm/vf-cli.jar'
+      wrapper_script_path: 'vf-cli'
+      jre_package: 'java-21-openjdk-headless'
+      artifact_name: 'vempain-file-cli-rpm'
+    secrets: inherit
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,9 @@ For complex native-SQL search (e.g. across joined tables), follow `FileGroupRepo
 ## Key Conventions
 
 - JSON field names use snake_case (`@JsonNaming(SnakeCaseStrategy.class)` in DTOs)
+- Snake_case is mandatory for all API JSON contracts; never add camelCase JSON field names in DTO annotations, request/response payloads, or docs/examples.
+- Prefer Jackson v3 `tools.jackson.databind.*` naming/mapper APIs for JSON configuration; keep non-`tools.jackson` annotations only when there is no
+  `tools.jackson` replacement available in current dependencies.
 - Test class suffix `ITC` = integration test, `UTC` = unit test
 - After every code modification, run relevant tests for touched modules and report the results in the response
 - Schema managed by Flyway; migrations under `service/src/main/resources/db/migration/`

--- a/api/src/main/java/fi/poltsi/vempain/file/rest/FileContentAPI.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/rest/FileContentAPI.java
@@ -1,0 +1,33 @@
+package fi.poltsi.vempain.file.rest;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "File Content API", description = "API for fetching original file bytes from storage")
+public interface FileContentAPI {
+
+	String BASE_PATH = "/files";
+
+	@Operation(summary = "Get file content by ID", description = "Streams original file bytes for the given file identifier")
+	@Parameter(name = "id", description = "File ID to fetch content for", example = "1")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "File content returned successfully"),
+			@ApiResponse(responseCode = "401", description = "Unauthorized access", content = @Content),
+			@ApiResponse(responseCode = "404", description = "File or file content not found", content = @Content),
+			@ApiResponse(responseCode = "500", description = "Internal server error", content = @Content)
+	})
+	@SecurityRequirement(name = "Bearer Authentication")
+	@GetMapping(path = BASE_PATH + "/{id}/content", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+	ResponseEntity<Resource> getFileContent(@PathVariable("id") long id);
+}
+

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,50 @@
+# Vempain File CLI
+
+Command-line client for the Vempain File backend API.
+
+## Features implemented
+
+- Login with backend URL + username + password, store JWT session locally
+- File-type specific listing via `PagedRequest`
+- Deterministic file show routing: `--type` + `--id`
+- Metadata + content display (text rendered, binary summarized)
+- Formatted tabular output for file listings with truncation for long values
+- `file-show` supports `--raw` and `--content-limit <n>`
+- Data publish commands (music + gps-time-series)
+- Scan command for original/export directories
+- Interactive shell with tab completion:
+    - file types in lowercase
+    - backend path completion for scan directories
+
+## Build
+
+```bash
+cd /home/poltsi/Work/Vempain/vempain-file-backend
+./gradlew :cli:fatJar
+```
+
+## Run
+
+```bash
+java -jar vf-cli.jar --help
+```
+
+## Usage examples
+
+```bash
+java -jar vf-cli.jar login --url http://localhost:8080/api --username admin --password qwerty
+java -jar vf-cli.jar files-list --type music --page 0 --size 25 --sort-by created --direction DESC
+java -jar vf-cli.jar file-show --type music --id 42
+java -jar vf-cli.jar file-show --type music --id 42 --content-limit 2048
+java -jar vf-cli.jar file-show --type music --id 42 --raw
+java -jar vf-cli.jar publish-music
+java -jar vf-cli.jar scan --original-directory /music
+java -jar vf-cli.jar shell
+```
+
+## Session storage
+
+Session is stored at:
+
+- `~/.config/vempain-file-cli/session.json`
+

--- a/cli/README.md
+++ b/cli/README.md
@@ -25,9 +25,24 @@ cd /home/poltsi/Work/Vempain/vempain-file-backend
 
 ## Run
 
+### Direct jar (development)
+
 ```bash
 java -jar vf-cli.jar --help
 ```
+
+### Wrapper script (RPM installation)
+
+After installing the `vempain-file-cli` RPM package, use:
+
+```bash
+vf-cli --help
+```
+
+Installed paths from RPM:
+
+- wrapper: `/usr/bin/vf-cli`
+- jar: `/usr/lib/vempain/file/vf-cli.jar`
 
 ## Usage examples
 

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -1,0 +1,100 @@
+plugins {
+	id 'application'
+	id 'java'
+	id 'jacoco'
+}
+
+group = 'fi.poltsi.vempain'
+version = project.hasProperty("releaseVersion") ? project.releaseVersion : '0.0.1-SNAPSHOT'
+
+java {
+	toolchain {
+		languageVersion = JavaLanguageVersion.of("${javaVersion}")
+	}
+}
+
+repositories {
+	mavenCentral()
+	maven {
+		url = "https://maven.pkg.github.com/Vempain/vempain-auth"
+		credentials {
+			username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
+			password = project.findProperty("gpr.token") ?: System.getenv("GITHUB_TOKEN")
+		}
+	}
+	maven {
+		url = "https://maven.pkg.github.com/Vempain/vempain-admin-backend-api"
+		credentials {
+			username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
+			password = project.findProperty("gpr.token") ?: System.getenv("GITHUB_TOKEN")
+		}
+	}
+}
+
+dependencies {
+	implementation project(':api')
+	implementation "com.beust:jcommander:1.82"
+	implementation "org.jline:jline:${jlineVersion}"
+	implementation "org.json:json:${jsonVersion}"
+	testImplementation "org.junit.jupiter:junit-jupiter:${junitVersion}"
+	testImplementation "org.junit.platform:junit-platform-launcher:${junitVersion}"
+	testImplementation "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
+}
+
+application {
+	mainClass = 'fi.poltsi.vempain.file.cli.VempainFileCliApplication'
+}
+
+tasks.named('test') {
+	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+jacoco {
+	toolVersion = "${jacocoVersion}"
+}
+
+jacocoTestReport {
+	dependsOn test
+	reports {
+		xml.required = true
+		html.required = true
+	}
+}
+
+jacocoTestCoverageVerification {
+	dependsOn test
+	violationRules {
+		rule {
+			element = 'PACKAGE'
+			includes = ['fi.poltsi.vempain.file.cli']
+			limit {
+				counter = 'LINE'
+				value = 'COVEREDRATIO'
+				minimum = 0.90
+			}
+		}
+	}
+}
+
+jar {
+	manifest {
+		attributes('Main-Class': application.mainClass.get())
+	}
+}
+
+tasks.register('fatJar', Jar) {
+	group = 'build'
+	description = 'Builds a runnable fat jar for the CLI module.'
+	archiveFileName = 'vf-cli.jar'
+	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+	dependsOn configurations.runtimeClasspath
+	from sourceSets.main.output
+	from {
+		configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+	}
+	manifest {
+		attributes('Main-Class': application.mainClass.get())
+	}
+}
+

--- a/cli/src/main/java/fi/poltsi/vempain/file/cli/BackendClient.java
+++ b/cli/src/main/java/fi/poltsi/vempain/file/cli/BackendClient.java
@@ -1,0 +1,102 @@
+package fi.poltsi.vempain.file.cli;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+public class BackendClient {
+
+	private final HttpClient httpClient = HttpClient.newBuilder()
+	                                                .connectTimeout(Duration.ofSeconds(10))
+	                                                .build();
+
+	public JSONObject login(String baseUrl, String username, String password) throws IOException, InterruptedException {
+		var requestJson = new JSONObject()
+				.put("login", username)
+				.put("password", password);
+
+		var response = request("POST", baseUrl, "/login", null, requestJson.toString(), "application/json");
+		if (response.statusCode() / 100 != 2) {
+			throw new IOException("Login failed: HTTP " + response.statusCode() + " body: " + responseBody(response));
+		}
+
+		var body = responseBody(response).trim();
+		if (body.startsWith("[")) {
+			var array = new JSONArray(body);
+			if (array.isEmpty()) {
+				throw new IOException("Login response array was empty");
+			}
+			return array.getJSONObject(0);
+		}
+		return new JSONObject(body);
+	}
+
+	public JSONObject getJson(SessionStore.Session session, String path) throws IOException, InterruptedException {
+		var response = request("GET", session.baseUrl(), path, session.token(), null, "application/json");
+		if (response.statusCode() / 100 != 2) {
+			throw new IOException("GET " + path + " failed: HTTP " + response.statusCode() + " body: " + responseBody(response));
+		}
+		return new JSONObject(responseBody(response));
+	}
+
+	public JSONObject postJson(SessionStore.Session session, String path, JSONObject body) throws IOException, InterruptedException {
+		var response = request("POST", session.baseUrl(), path, session.token(), body.toString(), "application/json");
+		if (response.statusCode() / 100 != 2) {
+			throw new IOException("POST " + path + " failed: HTTP " + response.statusCode() + " body: " + responseBody(response));
+		}
+		var payload = responseBody(response).trim();
+		if (payload.isEmpty()) {
+			return new JSONObject();
+		}
+		if (payload.startsWith("[")) {
+			var arr = new JSONArray(payload);
+			return new JSONObject().put("items", arr);
+		}
+		return new JSONObject(payload);
+	}
+
+	public HttpResponse<byte[]> getBytes(SessionStore.Session session, String path) throws IOException, InterruptedException {
+		var response = request("GET", session.baseUrl(), path, session.token(), null, "*/*");
+		if (response.statusCode() / 100 != 2) {
+			throw new IOException("GET " + path + " failed: HTTP " + response.statusCode() + " body: " + responseBody(response));
+		}
+		return response;
+	}
+
+	private HttpResponse<byte[]> request(String method,
+	                                     String baseUrl,
+	                                     String path,
+	                                     String token,
+	                                     String body,
+	                                     String accept) throws IOException, InterruptedException {
+		var fullUri = URI.create(baseUrl + (path.startsWith("/") ? path : "/" + path));
+		var builder = HttpRequest.newBuilder(fullUri)
+		                         .timeout(Duration.ofSeconds(30))
+		                         .header("Accept", accept);
+
+		if (token != null && !token.isBlank()) {
+			builder.header("Authorization", "Bearer " + token);
+		}
+
+		if ("POST".equals(method)) {
+			builder.header("Content-Type", "application/json");
+			builder.POST(HttpRequest.BodyPublishers.ofString(body == null ? "{}" : body, StandardCharsets.UTF_8));
+		} else {
+			builder.GET();
+		}
+
+		return httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofByteArray());
+	}
+
+	private String responseBody(HttpResponse<byte[]> response) {
+		return new String(response.body(), StandardCharsets.UTF_8);
+	}
+}
+

--- a/cli/src/main/java/fi/poltsi/vempain/file/cli/SessionStore.java
+++ b/cli/src/main/java/fi/poltsi/vempain/file/cli/SessionStore.java
@@ -1,0 +1,67 @@
+package fi.poltsi.vempain.file.cli;
+
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class SessionStore {
+
+	private Path sessionFile() {
+		return Path.of(System.getProperty("user.home"), ".config", "vempain-file-cli", "session.json");
+	}
+
+	public Session load() {
+		var sessionFile = sessionFile();
+		if (!Files.exists(sessionFile)) {
+			return null;
+		}
+		try {
+			var json    = new JSONObject(Files.readString(sessionFile, StandardCharsets.UTF_8));
+			var baseUrl = json.optString("base_url", null);
+			var token   = json.optString("token", null);
+			if (baseUrl == null || baseUrl.isBlank() || token == null || token.isBlank()) {
+				return null;
+			}
+			return new Session(baseUrl, token);
+		} catch (Exception ignored) {
+			return null;
+		}
+	}
+
+	public void save(String baseUrl, String token) throws IOException {
+		var sessionFile = sessionFile();
+		Files.createDirectories(sessionFile.getParent());
+		var json = new JSONObject();
+		json.put("base_url", normalizeBaseUrl(baseUrl));
+		json.put("token", token);
+		Files.writeString(sessionFile, json.toString(2), StandardCharsets.UTF_8);
+	}
+
+	public void clear() throws IOException {
+		Files.deleteIfExists(sessionFile());
+	}
+
+	public String normalizeBaseUrl(String baseUrl) {
+		var trimmed = baseUrl == null ? "" : baseUrl.trim();
+		while (trimmed.endsWith("/")) {
+			trimmed = trimmed.substring(0, trimmed.length() - 1);
+		}
+		if (trimmed.endsWith("/api")) {
+			return trimmed;
+		}
+		if (!trimmed.contains("/")) {
+			return "http://" + trimmed + "/api";
+		}
+		if (!trimmed.matches("^https?://.*$")) {
+			trimmed = "http://" + trimmed;
+		}
+		return trimmed.endsWith("/api") ? trimmed : trimmed + "/api";
+	}
+
+	public record Session(String baseUrl, String token) {
+	}
+}
+

--- a/cli/src/main/java/fi/poltsi/vempain/file/cli/VempainFileCliApplication.java
+++ b/cli/src/main/java/fi/poltsi/vempain/file/cli/VempainFileCliApplication.java
@@ -1,0 +1,498 @@
+package fi.poltsi.vempain.file.cli;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+import com.beust.jcommander.Parameters;
+import fi.poltsi.vempain.file.api.FileTypeEnum;
+import org.jline.reader.Candidate;
+import org.jline.reader.Completer;
+import org.jline.reader.EndOfFileException;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.ParsedLine;
+import org.jline.reader.UserInterruptException;
+import org.jline.reader.impl.completer.StringsCompleter;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.PrintStream;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class VempainFileCliApplication {
+
+	private static final Set<String> FILE_TYPES = Arrays.stream(FileTypeEnum.values())
+	                                                    .filter(t -> t != FileTypeEnum.UNKNOWN)
+	                                                    .map(t -> t.shortName)
+	                                                    .collect(Collectors.toSet());
+
+	private final SessionStore  sessionStore;
+	private final BackendClient backendClient;
+	private final PrintStream   out;
+	private final PrintStream   err;
+
+	public VempainFileCliApplication() {
+		this(new SessionStore(), new BackendClient(), System.out, System.err);
+	}
+
+	VempainFileCliApplication(SessionStore sessionStore, BackendClient backendClient, PrintStream out, PrintStream err) {
+		this.sessionStore  = sessionStore;
+		this.backendClient = backendClient;
+		this.out           = out;
+		this.err           = err;
+	}
+
+	public static void main(String[] args) {
+		new VempainFileCliApplication().run(args);
+	}
+
+	void run(String[] args) {
+		var root         = new RootArgs();
+		var login        = new LoginCommand();
+		var list         = new ListCommand();
+		var show         = new ShowCommand();
+		var publishMusic = new PublishMusicCommand();
+		var publishGps   = new PublishGpsCommand();
+		var scan         = new ScanCommand();
+		var logout       = new LogoutCommand();
+		var shell        = new ShellCommand();
+
+		var jc = JCommander.newBuilder()
+		                   .programName("vempain-file-cli")
+		                   .addObject(root)
+		                   .addCommand("login", login)
+		                   .addCommand("files-list", list)
+		                   .addCommand("file-show", show)
+		                   .addCommand("publish-music", publishMusic)
+		                   .addCommand("publish-gps", publishGps)
+		                   .addCommand("scan", scan)
+		                   .addCommand("logout", logout)
+		                   .addCommand("shell", shell)
+		                   .build();
+
+		if (args.length == 0) {
+			jc.usage();
+			return;
+		}
+
+		try {
+			jc.parse(args);
+		} catch (ParameterException e) {
+			err.println(e.getMessage());
+			jc.usage();
+			return;
+		}
+
+		if (root.help) {
+			jc.usage();
+			return;
+		}
+
+		var command = jc.getParsedCommand();
+		if (command == null) {
+			jc.usage();
+			return;
+		}
+
+		try {
+			switch (command) {
+				case "login" -> login(login);
+				case "files-list" -> listFiles(list);
+				case "file-show" -> showFile(show);
+				case "publish-music" -> publishMusic();
+				case "publish-gps" -> publishGps(publishGps);
+				case "scan" -> scan(scan);
+				case "logout" -> logout();
+				case "shell" -> shell();
+				default -> jc.usage();
+			}
+		} catch (Exception e) {
+			err.println("Error: " + e.getMessage());
+		}
+	}
+
+	private void login(LoginCommand command) throws Exception {
+		var baseUrl  = sessionStore.normalizeBaseUrl(command.url);
+		var response = backendClient.login(baseUrl, command.username, command.password);
+		var token    = response.optString("token", "");
+		if (token.isBlank()) {
+			throw new IllegalStateException("Login response did not include token");
+		}
+		sessionStore.save(baseUrl, token);
+		out.println("Login successful. Session saved for " + baseUrl);
+	}
+
+	private void listFiles(ListCommand command) throws Exception {
+		validateType(command.type);
+		var session = requireSession();
+
+		var request = new JSONObject();
+		request.put("page", command.page);
+		request.put("size", command.size);
+		if (command.sortBy != null) {
+			request.put("sort_by", command.sortBy);
+		}
+		if (command.direction != null) {
+			request.put("direction", command.direction.toUpperCase(Locale.ROOT));
+		}
+		if (command.search != null) {
+			request.put("search", command.search);
+		}
+		request.put("case_sensitive", command.caseSensitive);
+
+		var response = backendClient.postJson(session, "/files/" + command.type + "/paged", request);
+		var content  = response.optJSONArray("content");
+		if (content == null || content.isEmpty()) {
+			out.println("No files found.");
+			return;
+		}
+
+		out.printf("%-8s %-36s %-13s %-12s %-25s%n", "id", "filename", "file_type", "filesize", "created");
+		out.println("-".repeat(100));
+		for (int i = 0; i < content.length(); i++) {
+			var item = content.getJSONObject(i);
+			out.printf("%-8d %-36s %-13s %-12d %-25s%n",
+			           item.optLong("id", 0L),
+			           truncate(item.optString("filename", ""), 36),
+			           truncate(item.optString("file_type", ""), 13),
+			           item.optLong("filesize", 0L),
+			           truncate(item.optString("created", ""), 25));
+		}
+
+		out.printf("%nPage %d/%d, total elements: %d%n",
+		           response.optInt("page", 0),
+		           response.has("totalPages") ? response.optInt("totalPages", response.optInt("total_pages", 0)) : response.optInt("total_pages", 0),
+		           response.has("totalElements") ? response.optLong("totalElements", response.optLong("total_elements", 0L)) : response.optLong("total_elements", 0L));
+	}
+
+	private void showFile(ShowCommand command) throws Exception {
+		validateType(command.type);
+		var session = requireSession();
+
+		var metadata = backendClient.getJson(session, "/files/" + command.type + "/" + command.id);
+		printMetadata(metadata, command.raw);
+
+		HttpResponse<byte[]> contentResponse = backendClient.getBytes(session, "/files/" + command.id + "/content");
+		var                  contentType     = contentResponse.headers()
+		                                                      .firstValue("content-type")
+		                                                      .orElse("application/octet-stream");
+		var                  bytes           = contentResponse.body();
+
+		if (isTextualContent(contentType)) {
+			var text   = new String(bytes, StandardCharsets.UTF_8);
+			var maxLen = Math.max(0, command.contentLimit);
+			if (!command.raw && text.length() > maxLen) {
+				out.printf("%nContent (truncated to %d chars):%n", maxLen);
+				out.println(text.substring(0, maxLen));
+			} else {
+				out.println("\nContent:");
+				out.println(text);
+			}
+		} else {
+			out.printf("%nBinary content (%d bytes, content-type=%s) is not displayed.%n", bytes.length, contentType);
+		}
+	}
+
+	private void publishMusic() throws Exception {
+		var session  = requireSession();
+		var response = backendClient.postJson(session, "/data-publish/music", new JSONObject());
+		out.println(response.toString(2));
+	}
+
+	private void publishGps(PublishGpsCommand command) throws Exception {
+		var session = requireSession();
+		var request = new JSONObject()
+				.put("file_group_id", command.fileGroupId)
+				.put("time_series_name", command.timeSeriesName);
+		var response = backendClient.postJson(session, "/data-publish/gps-timeseries", request);
+		out.println(response.toString(2));
+	}
+
+	private void scan(ScanCommand command) throws Exception {
+		var session = requireSession();
+		if ((command.originalDirectory == null || command.originalDirectory.isBlank())
+		    && (command.exportDirectory == null || command.exportDirectory.isBlank())) {
+			throw new IllegalArgumentException("Provide --original-directory and/or --export-directory");
+		}
+
+		var request = new JSONObject();
+		if (command.originalDirectory != null && !command.originalDirectory.isBlank()) {
+			request.put("original_directory", command.originalDirectory);
+		}
+		if (command.exportDirectory != null && !command.exportDirectory.isBlank()) {
+			request.put("export_directory", command.exportDirectory);
+		}
+
+		var response = backendClient.postJson(session, "/scan-files", request);
+		if (response.has("items") && response.get("items") instanceof JSONArray arr) {
+			out.println(arr.toString(2));
+		} else {
+			out.println(response.toString(2));
+		}
+	}
+
+	private void logout() throws Exception {
+		sessionStore.clear();
+		out.println("Session removed.");
+	}
+
+	private void shell() {
+		var reader = LineReaderBuilder.builder()
+		                              .completer(new CliCompleter())
+		                              .build();
+		runShell(reader);
+	}
+
+	void runShell(LineReader reader) {
+		out.println("Interactive shell started. Type 'exit' to quit.");
+
+		while (true) {
+			try {
+				var line = reader.readLine("vempain-file> ");
+				if (line == null) {
+					continue;
+				}
+				var trimmed = line.trim();
+				if (trimmed.isEmpty()) {
+					continue;
+				}
+				if ("exit".equalsIgnoreCase(trimmed) || "quit".equalsIgnoreCase(trimmed)) {
+					break;
+				}
+				run(splitArgs(trimmed));
+			} catch (UserInterruptException ignored) {
+			} catch (EndOfFileException ignored) {
+				break;
+			}
+		}
+	}
+
+	private SessionStore.Session requireSession() {
+		var session = sessionStore.load();
+		if (session == null) {
+			throw new IllegalStateException("Not logged in. Run: login --url <url> --username <user> --password <pass>");
+		}
+		return session;
+	}
+
+	private void validateType(String type) {
+		if (type == null || !FILE_TYPES.contains(type.toLowerCase(Locale.ROOT))) {
+			throw new IllegalArgumentException("Invalid --type. Allowed values: " + String.join(", ", FILE_TYPES));
+		}
+	}
+
+	private boolean isTextualContent(String contentType) {
+		var lower = contentType.toLowerCase(Locale.ROOT);
+		return lower.startsWith("text/")
+		       || lower.contains("application/json")
+		       || lower.contains("application/xml")
+		       || lower.contains("application/javascript");
+	}
+
+	private void printMetadata(JSONObject metadata, boolean raw) {
+		out.println("Metadata:");
+		if (raw) {
+			out.println(metadata.toString(2));
+			return;
+		}
+
+		out.println("  [Identity]");
+		out.println("    id: " + metadata.optLong("id", 0));
+		out.println("    filename: " + metadata.optString("filename", ""));
+		out.println("    file_type: " + metadata.optString("file_type", ""));
+		out.println("    mimetype: " + metadata.optString("mimetype", ""));
+		out.println("    filesize: " + metadata.optLong("filesize", 0));
+		out.println("  [Timestamps]");
+		out.println("    created: " + metadata.optString("created", ""));
+		out.println("    modified: " + metadata.optString("modified", ""));
+		out.println("    original_datetime: " + metadata.optString("original_datetime", ""));
+	}
+
+	private String truncate(String value, int maxLength) {
+		if (value == null) {
+			return "";
+		}
+		if (value.length() <= maxLength || maxLength < 4) {
+			return value;
+		}
+		return value.substring(0, maxLength - 3) + "...";
+	}
+
+	private String[] splitArgs(String commandLine) {
+		List<String> tokens  = new ArrayList<>();
+		Matcher      matcher = Pattern.compile("\\\"([^\\\"]*)\\\"|'([^']*)'|(\\S+)")
+		                              .matcher(commandLine);
+		while (matcher.find()) {
+			if (matcher.group(1) != null) {
+				tokens.add(matcher.group(1));
+			} else if (matcher.group(2) != null) {
+				tokens.add(matcher.group(2));
+			} else {
+				tokens.add(matcher.group(3));
+			}
+		}
+		return tokens.toArray(new String[0]);
+	}
+
+	private class CliCompleter implements Completer {
+
+		private final StringsCompleter commandCompleter = new StringsCompleter(
+				"login", "files-list", "file-show", "publish-music", "publish-gps", "scan", "logout", "shell", "exit", "quit"
+		);
+
+		@Override
+		public void complete(LineReader reader, ParsedLine line, List<Candidate> candidates) {
+			if (line.wordIndex() == 0) {
+				commandCompleter.complete(reader, line, candidates);
+				return;
+			}
+
+			var words = line.words();
+			if (words.isEmpty()) {
+				return;
+			}
+			var command = words.get(0);
+
+			if (("files-list".equals(command) || "file-show".equals(command)) && wantsTypeCompletion(words, line.wordIndex())) {
+				FILE_TYPES.stream()
+				          .sorted()
+				          .forEach(type -> candidates.add(new Candidate(type)));
+				return;
+			}
+
+			if ("scan".equals(command)) {
+				completeScanPath(words, line.wordIndex(), candidates, line.word());
+			}
+		}
+
+		private boolean wantsTypeCompletion(List<String> words, int wordIndex) {
+			if (wordIndex <= 0) {
+				return false;
+			}
+			var previous = words.get(Math.max(0, wordIndex - 1));
+			return "--type".equals(previous) || "-t".equals(previous);
+		}
+
+		private void completeScanPath(List<String> words, int wordIndex, List<Candidate> candidates, String currentWord) {
+			if (wordIndex <= 0) {
+				return;
+			}
+			var    previous = words.get(Math.max(0, wordIndex - 1));
+			String completionType;
+			if ("--original-directory".equals(previous) || "-o".equals(previous)) {
+				completionType = "ORIGINAL";
+			} else if ("--export-directory".equals(previous) || "-e".equals(previous)) {
+				completionType = "EXPORTED";
+			} else {
+				return;
+			}
+
+			var session = sessionStore.load();
+			if (session == null) {
+				return;
+			}
+
+			var path    = (currentWord == null || currentWord.isBlank()) ? "/" : currentWord;
+			var request = new JSONObject().put("path", path)
+			                              .put("type", completionType);
+			try {
+				var response    = backendClient.postJson(session, "/path-completion", request);
+				var completions = response.optJSONArray("completions");
+				if (completions == null) {
+					return;
+				}
+				for (int i = 0; i < completions.length(); i++) {
+					candidates.add(new Candidate(completions.getString(i)));
+				}
+			} catch (Exception ignored) {
+			}
+		}
+	}
+
+	Completer createCompleterForTests() {
+		return new CliCompleter();
+	}
+
+	private static class RootArgs {
+		@Parameter(names = {"-h", "--help"}, help = true, description = "Show help")
+		boolean help;
+	}
+
+	@Parameters(commandDescription = "Authenticate and store session")
+	private static class LoginCommand {
+		@Parameter(names = {"--url"}, required = true, description = "Backend base URL (e.g. http://localhost:8080/api)")
+		String url;
+		@Parameter(names = {"--username"}, required = true, description = "Username")
+		String username;
+		@Parameter(names = {"--password"}, required = true, password = true, description = "Password")
+		String password;
+	}
+
+	@Parameters(commandDescription = "List files for one file type with paging")
+	private static class ListCommand {
+		@Parameter(names = {"-t", "--type"}, required = true, description = "File type in lowercase")
+		String  type;
+		@Parameter(names = {"-p", "--page"}, description = "Page number (0-based)")
+		int     page          = 0;
+		@Parameter(names = {"-s", "--size"}, description = "Page size")
+		int     size          = 25;
+		@Parameter(names = {"--sort-by"}, description = "Sort field")
+		String  sortBy        = "filename";
+		@Parameter(names = {"--direction"}, description = "Sort direction ASC|DESC")
+		String  direction     = "ASC";
+		@Parameter(names = {"--search"}, description = "Search query")
+		String  search;
+		@Parameter(names = {"--case-sensitive"}, description = "Case-sensitive search")
+		boolean caseSensitive = false;
+	}
+
+	@Parameters(commandDescription = "Show file metadata and content for one typed file")
+	private static class ShowCommand {
+		@Parameter(names = {"-t", "--type"}, required = true, description = "File type in lowercase")
+		String  type;
+		@Parameter(names = {"-i", "--id"}, required = true, description = "File ID")
+		long    id;
+		@Parameter(names = {"--raw"}, description = "Show raw metadata JSON and do not truncate text content")
+		boolean raw;
+		@Parameter(names = {"--content-limit"}, description = "Maximum number of chars shown for textual content")
+		int     contentLimit = 8_192;
+	}
+
+	@Parameters(commandDescription = "Generate and publish music dataset")
+	private static class PublishMusicCommand {
+	}
+
+	@Parameters(commandDescription = "Generate and publish GPS time-series dataset")
+	private static class PublishGpsCommand {
+		@Parameter(names = {"--file-group-id"}, required = true, description = "File group ID")
+		long   fileGroupId;
+		@Parameter(names = {"--time-series-name"}, required = true, description = "Time-series identifier")
+		String timeSeriesName;
+	}
+
+	@Parameters(commandDescription = "Trigger backend file scan")
+	private static class ScanCommand {
+		@Parameter(names = {"-o", "--original-directory"}, description = "Original directory path")
+		String originalDirectory;
+		@Parameter(names = {"-e", "--export-directory"}, description = "Export directory path")
+		String exportDirectory;
+	}
+
+	@Parameters(commandDescription = "Clear stored session")
+	private static class LogoutCommand {
+	}
+
+	@Parameters(commandDescription = "Start interactive shell (supports tab completion)")
+	private static class ShellCommand {
+	}
+}
+

--- a/cli/src/test/java/fi/poltsi/vempain/file/cli/BackendClientUTC.java
+++ b/cli/src/test/java/fi/poltsi/vempain/file/cli/BackendClientUTC.java
@@ -1,0 +1,108 @@
+package fi.poltsi.vempain.file.cli;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BackendClientUTC {
+
+	private HttpServer server;
+	private String     baseUrl;
+
+	@BeforeEach
+	void setUp() throws IOException {
+		server  = HttpServer.create(new InetSocketAddress(0), 0);
+		baseUrl = "http://localhost:" + server.getAddress()
+		                                      .getPort() + "/api";
+		server.start();
+	}
+
+	@AfterEach
+	void tearDown() {
+		server.stop(0);
+	}
+
+	@Test
+	void login_parsesObjectResponse() throws Exception {
+		register("/api/login", 200, "application/json", "{\"token\":\"token-obj\"}");
+
+		var client   = new BackendClient();
+		var response = client.login(baseUrl, "user", "pass");
+
+		assertEquals("token-obj", response.getString("token"));
+	}
+
+	@Test
+	void postJson_wrapsArrayPayloadAsItems() throws Exception {
+		register("/api/scan-files", 200, "application/json", "[{\"success\":true}]");
+
+		var client   = new BackendClient();
+		var response = client.postJson(new SessionStore.Session(baseUrl, "abc"), "/scan-files", new JSONObject());
+
+		assertTrue(response.has("items"));
+	}
+
+	@Test
+	void getJson_throwsOnNon2xx() {
+		register("/api/files/music/1", 404, "application/json", "{\"error\":\"not found\"}");
+
+		var client = new BackendClient();
+		var exception = assertThrows(IOException.class,
+		                             () -> client.getJson(new SessionStore.Session(baseUrl, "abc"), "/files/music/1"));
+		assertTrue(exception.getMessage()
+		                    .contains("HTTP 404"));
+	}
+
+	@Test
+	void getBytes_returnsPayload() throws Exception {
+		register("/api/files/42/content", 200, "text/plain", "content");
+
+		var client   = new BackendClient();
+		var response = client.getBytes(new SessionStore.Session(baseUrl, "abc"), "/files/42/content");
+		assertEquals("content", new String(response.body(), StandardCharsets.UTF_8));
+	}
+
+	@Test
+	void login_emptyArrayThrows() {
+		register("/api/login", 200, "application/json", "[]");
+
+		var client    = new BackendClient();
+		var exception = assertThrows(IOException.class, () -> client.login(baseUrl, "user", "pass"));
+		assertTrue(exception.getMessage()
+		                    .contains("empty"));
+	}
+
+	@Test
+	void postJson_emptyBodyReturnsEmptyJsonObject() throws Exception {
+		register("/api/empty", 200, "application/json", "");
+
+		var client   = new BackendClient();
+		var response = client.postJson(new SessionStore.Session(baseUrl, "abc"), "/empty", new JSONObject());
+		assertEquals(0, response.length());
+	}
+
+	private void register(String path, int code, String contentType, String body) {
+		var bytes = body.getBytes(StandardCharsets.UTF_8);
+		server.createContext(path, (HttpExchange exchange) -> {
+			exchange.getResponseHeaders()
+			        .set("Content-Type", contentType);
+			exchange.sendResponseHeaders(code, bytes.length);
+			try (OutputStream os = exchange.getResponseBody()) {
+				os.write(bytes);
+			}
+		});
+	}
+}
+

--- a/cli/src/test/java/fi/poltsi/vempain/file/cli/CliIntegrationUTC.java
+++ b/cli/src/test/java/fi/poltsi/vempain/file/cli/CliIntegrationUTC.java
@@ -1,0 +1,389 @@
+package fi.poltsi.vempain.file.cli;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.jline.reader.Candidate;
+import org.jline.reader.EndOfFileException;
+import org.jline.reader.LineReader;
+import org.jline.reader.ParsedLine;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.lang.reflect.Proxy;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CliIntegrationUTC {
+
+	@TempDir
+	Path tempHome;
+
+	private String previousHome;
+
+	@BeforeEach
+	void setUp() {
+		previousHome = System.getProperty("user.home");
+		System.setProperty("user.home", tempHome.toString());
+	}
+
+	@AfterEach
+	void tearDown() {
+		System.setProperty("user.home", previousHome);
+	}
+
+	@Test
+	void loginAndFilesList_formatsOutputTable() throws Exception {
+		try (var server = new MockApiServer()) {
+			server.registerJson("/api/login", "[{\"token\":\"jwt-1\"}]");
+			server.registerJson("/api/files/music/paged",
+			                    """
+										{
+										  "content": [
+										    {
+										      "id": 42,
+										      "filename": "this-is-a-very-long-file-name-that-needs-truncation.mp3",
+										      "file_type": "MUSIC",
+										      "filesize": 123456,
+										      "created": "2026-05-14T12:00:00Z"
+										    }
+										  ],
+										  "page": 0,
+										  "total_pages": 1,
+										  "total_elements": 1
+										}
+										""");
+
+			var outBytes = new ByteArrayOutputStream();
+			var errBytes = new ByteArrayOutputStream();
+			var app      = new VempainFileCliApplication(new SessionStore(), new BackendClient(), new PrintStream(outBytes), new PrintStream(errBytes));
+
+			app.run(new String[]{"login", "--url", server.baseUrl(), "--username", "admin", "--password", "secret"});
+			app.run(new String[]{"files-list", "--type", "music", "--size", "10"});
+
+			var output = outBytes.toString(StandardCharsets.UTF_8);
+			assertTrue(output.contains("Login successful"));
+			assertTrue(output.contains("id       filename"));
+			assertTrue(output.contains("Page 0/1, total elements: 1"));
+			assertTrue(output.contains("..."));
+			assertFalse(errBytes.toString(StandardCharsets.UTF_8)
+			                    .contains("Error:"));
+		}
+	}
+
+	@Test
+	void fileShow_supportsContentLimitAndRaw() throws Exception {
+		try (var server = new MockApiServer()) {
+			server.registerJson("/api/files/music/42",
+			                    """
+										{
+										  "id": 42,
+										  "filename": "song.txt",
+										  "file_type": "MUSIC",
+										  "mimetype": "text/plain",
+										  "filesize": 20,
+										  "created": "2026-05-14T12:00:00Z"
+										}
+										""");
+			server.registerBytes("/api/files/42/content", "text/plain", "0123456789abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.UTF_8));
+
+			var sessionStore = new SessionStore();
+			sessionStore.save(server.baseUrl(), "jwt-2");
+
+			var outBytes = new ByteArrayOutputStream();
+			var app      = new VempainFileCliApplication(sessionStore, new BackendClient(), new PrintStream(outBytes), System.err);
+
+			app.run(new String[]{"file-show", "--type", "music", "--id", "42", "--content-limit", "10"});
+			var truncatedOutput = outBytes.toString(StandardCharsets.UTF_8);
+			assertTrue(truncatedOutput.contains("Metadata:"));
+			assertTrue(truncatedOutput.contains("Content (truncated to 10 chars):"));
+
+			outBytes.reset();
+			app.run(new String[]{"file-show", "--type", "music", "--id", "42", "--raw", "--content-limit", "10"});
+			var rawOutput = outBytes.toString(StandardCharsets.UTF_8);
+			assertTrue(rawOutput.contains("\"filename\": \"song.txt\""));
+			assertFalse(rawOutput.contains("Content (truncated to 10 chars):"));
+			assertTrue(rawOutput.contains("abcdefghijklmnopqrstuvwxyz"));
+		}
+	}
+
+	@Test
+	void shellCompletion_completesFileTypeAndPath() throws Exception {
+		try (var server = new MockApiServer()) {
+			server.registerJson("/api/path-completion", "{\"completions\":[\"/music\",\"/museum\"]}");
+
+			var sessionStore = new SessionStore();
+			sessionStore.save(server.baseUrl(), "jwt-3");
+
+			var app       = new VempainFileCliApplication(sessionStore, new BackendClient(), System.out, System.err);
+			var completer = app.createCompleterForTests();
+
+			var typeCandidates = new ArrayList<Candidate>();
+			completer.complete(null, new StubParsedLine(List.of("file-show", "--type", "m"), 2, "m"), typeCandidates);
+			assertTrue(typeCandidates.stream()
+			                         .anyMatch(c -> "music".equals(c.value())));
+
+			var pathCandidates = new ArrayList<Candidate>();
+			completer.complete(null, new StubParsedLine(List.of("scan", "--original-directory", "/mu"), 2, "/mu"), pathCandidates);
+			assertTrue(pathCandidates.stream()
+			                         .anyMatch(c -> "/music".equals(c.value())));
+		}
+	}
+
+	@Test
+	void publishScanAndLogout_workEndToEnd() throws Exception {
+		try (var server = new MockApiServer()) {
+			server.registerJson("/api/data-publish/music", "{\"identifier\":\"music_library\",\"status\":\"ok\"}");
+			server.registerJson("/api/data-publish/gps-timeseries", "{\"identifier\":\"gps_timeseries_demo\",\"status\":\"ok\"}");
+			server.registerJson("/api/scan-files", "[{\"success\":true,\"newFilesCount\":1}]");
+
+			var sessionStore = new SessionStore();
+			sessionStore.save(server.baseUrl(), "jwt-4");
+
+			var outBytes = new ByteArrayOutputStream();
+			var errBytes = new ByteArrayOutputStream();
+			var app      = new VempainFileCliApplication(sessionStore, new BackendClient(), new PrintStream(outBytes), new PrintStream(errBytes));
+
+			app.run(new String[]{"publish-music"});
+			app.run(new String[]{"publish-gps", "--file-group-id", "10", "--time-series-name", "demo"});
+			app.run(new String[]{"scan", "--original-directory", "/music"});
+			app.run(new String[]{"logout"});
+
+			var output = outBytes.toString(StandardCharsets.UTF_8);
+			assertTrue(output.contains("music_library"));
+			assertTrue(output.contains("gps_timeseries_demo"));
+			assertTrue(output.contains("newFilesCount"));
+			assertTrue(output.contains("Session removed."));
+			assertTrue(sessionStore.load() == null);
+			assertTrue(errBytes.toString(StandardCharsets.UTF_8)
+			                   .isBlank());
+		}
+	}
+
+	@Test
+	void errorPaths_areReportedToStderr() throws Exception {
+		var outBytes = new ByteArrayOutputStream();
+		var errBytes = new ByteArrayOutputStream();
+		var app      = new VempainFileCliApplication(new SessionStore(), new BackendClient(), new PrintStream(outBytes), new PrintStream(errBytes));
+
+		app.run(new String[]{"files-list", "--type", "music"});
+		app.run(new String[]{"files-list", "--type", "notatype"});
+
+		var sessionStore = new SessionStore();
+		sessionStore.save("http://localhost:8080/api", "jwt-x");
+		var appWithSession = new VempainFileCliApplication(sessionStore, new BackendClient(), new PrintStream(outBytes), new PrintStream(errBytes));
+		appWithSession.run(new String[]{"scan"});
+
+		var err = errBytes.toString(StandardCharsets.UTF_8);
+		assertTrue(err.contains("Not logged in"));
+		assertTrue(err.contains("Invalid --type"));
+		assertTrue(err.contains("Provide --original-directory and/or --export-directory"));
+	}
+
+	@Test
+	void runShell_processesLineAndExits() throws Exception {
+		try (var server = new MockApiServer()) {
+			server.registerJson("/api/files/music/paged", "{\"content\":[],\"page\":0,\"total_pages\":0,\"total_elements\":0}");
+
+			var sessionStore = new SessionStore();
+			sessionStore.save(server.baseUrl(), "jwt-5");
+
+			var outBytes = new ByteArrayOutputStream();
+			var app      = new VempainFileCliApplication(sessionStore, new BackendClient(), new PrintStream(outBytes), System.err);
+
+			var inputs = new ArrayDeque<String>();
+			inputs.add("files-list --type music");
+			inputs.add("exit");
+			LineReader reader = (LineReader) Proxy.newProxyInstance(
+					LineReader.class.getClassLoader(),
+					new Class[]{LineReader.class},
+					(proxy, method, args) -> {
+						if ("readLine".equals(method.getName())) {
+							var next = inputs.poll();
+							if (next == null) {
+								throw new EndOfFileException();
+							}
+							return next;
+						}
+						if (method.getReturnType()
+						          .equals(boolean.class)) {
+							return false;
+						}
+						if (method.getReturnType()
+						          .equals(int.class)) {
+							return 0;
+						}
+						return null;
+					}
+			);
+
+			app.runShell(reader);
+			var output = outBytes.toString(StandardCharsets.UTF_8);
+			assertTrue(output.contains("Interactive shell started"));
+			assertTrue(output.contains("No files found."));
+		}
+	}
+
+	@Test
+	void commandCompletion_suggestsCommandNames() {
+		var app        = new VempainFileCliApplication(new SessionStore(), new BackendClient(), System.out, System.err);
+		var completer  = app.createCompleterForTests();
+		var candidates = new ArrayList<Candidate>();
+		completer.complete(null, new StubParsedLine(List.of(""), 0, ""), candidates);
+		assertTrue(candidates.stream()
+		                     .anyMatch(c -> "file-show".equals(c.value())));
+	}
+
+	@Test
+	void usageAndParseErrors_areHandled() {
+		var outBytes = new ByteArrayOutputStream();
+		var errBytes = new ByteArrayOutputStream();
+		var app      = new VempainFileCliApplication(new SessionStore(), new BackendClient(), new PrintStream(outBytes), new PrintStream(errBytes));
+
+		app.run(new String[]{});
+		app.run(new String[]{"--help"});
+		app.run(new String[]{"files-list", "--unknown"});
+
+		var err = errBytes.toString(StandardCharsets.UTF_8);
+		assertTrue(err.contains("Was passed main parameter") || err.contains("Unknown option"));
+	}
+
+	@Test
+	void fileShow_binaryContentMessageIsPrinted() throws Exception {
+		try (var server = new MockApiServer()) {
+			server.registerJson("/api/files/music/99", "{\"id\":99,\"filename\":\"bin.dat\",\"file_type\":\"MUSIC\",\"mimetype\":\"application/octet-stream\"}");
+			server.registerBytes("/api/files/99/content", "application/octet-stream", new byte[]{1, 2, 3, 4});
+
+			var sessionStore = new SessionStore();
+			sessionStore.save(server.baseUrl(), "jwt-6");
+
+			var outBytes = new ByteArrayOutputStream();
+			var app      = new VempainFileCliApplication(sessionStore, new BackendClient(), new PrintStream(outBytes), System.err);
+			app.run(new String[]{"file-show", "--type", "music", "--id", "99"});
+
+			assertTrue(outBytes.toString(StandardCharsets.UTF_8)
+			                   .contains("Binary content (4 bytes"));
+		}
+	}
+
+	@Test
+	void scanCompletion_withoutSessionProducesNoCandidates() {
+		var app        = new VempainFileCliApplication(new SessionStore(), new BackendClient(), System.out, System.err);
+		var completer  = app.createCompleterForTests();
+		var candidates = new ArrayList<Candidate>();
+		completer.complete(null, new StubParsedLine(List.of("scan", "--export-directory", "/ex"), 2, "/ex"), candidates);
+		assertTrue(candidates.isEmpty());
+	}
+
+	@Test
+	void loginWithoutToken_reportsError() throws Exception {
+		try (var server = new MockApiServer()) {
+			server.registerJson("/api/login", "{}");
+
+			var outBytes = new ByteArrayOutputStream();
+			var errBytes = new ByteArrayOutputStream();
+			var app      = new VempainFileCliApplication(new SessionStore(), new BackendClient(), new PrintStream(outBytes), new PrintStream(errBytes));
+			app.run(new String[]{"login", "--url", server.baseUrl(), "--username", "admin", "--password", "pw"});
+
+			assertTrue(errBytes.toString(StandardCharsets.UTF_8)
+			                   .contains("Login response did not include token"));
+		}
+	}
+
+	private static class StubParsedLine implements ParsedLine {
+		private final List<String> words;
+		private final int          wordIndex;
+		private final String       word;
+
+		private StubParsedLine(List<String> words, int wordIndex, String word) {
+			this.words     = words;
+			this.wordIndex = wordIndex;
+			this.word      = word;
+		}
+
+		@Override
+		public String word() {
+			return word;
+		}
+
+		@Override
+		public int wordCursor() {
+			return word.length();
+		}
+
+		@Override
+		public int wordIndex() {
+			return wordIndex;
+		}
+
+		@Override
+		public List<String> words() {
+			return words;
+		}
+
+		@Override
+		public String line() {
+			return String.join(" ", words);
+		}
+
+		@Override
+		public int cursor() {
+			return line().length();
+		}
+	}
+
+	private static class MockApiServer implements AutoCloseable {
+		private final HttpServer server;
+
+		private MockApiServer() throws IOException {
+			server = HttpServer.create(new InetSocketAddress(0), 0);
+			server.start();
+		}
+
+		private void registerJson(String path, String responseBody) {
+			register(path, "application/json", responseBody.getBytes(StandardCharsets.UTF_8));
+		}
+
+		private void registerBytes(String path, String contentType, byte[] responseBody) {
+			register(path, contentType, responseBody);
+		}
+
+		private void register(String path, String contentType, byte[] responseBody) {
+			server.createContext(path, new HttpHandler() {
+				@Override
+				public void handle(HttpExchange exchange) throws IOException {
+					exchange.getResponseHeaders()
+					        .add("Content-Type", contentType);
+					exchange.sendResponseHeaders(200, responseBody.length);
+					try (OutputStream os = exchange.getResponseBody()) {
+						os.write(responseBody);
+					}
+				}
+			});
+		}
+
+		private String baseUrl() {
+			return "http://localhost:" + server.getAddress()
+			                                   .getPort() + "/api";
+		}
+
+		@Override
+		public void close() {
+			server.stop(0);
+		}
+	}
+}
+

--- a/cli/src/test/java/fi/poltsi/vempain/file/cli/SessionStoreUTC.java
+++ b/cli/src/test/java/fi/poltsi/vempain/file/cli/SessionStoreUTC.java
@@ -1,0 +1,79 @@
+package fi.poltsi.vempain.file.cli;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class SessionStoreUTC {
+
+	private final SessionStore sessionStore = new SessionStore();
+	private       String       previousHome;
+
+	@TempDir
+	Path tempHome;
+
+	@BeforeEach
+	void setUp() {
+		previousHome = System.getProperty("user.home");
+		System.setProperty("user.home", tempHome.toString());
+	}
+
+	@AfterEach
+	void tearDown() {
+		System.setProperty("user.home", previousHome);
+	}
+
+	@Test
+	void normalizeBaseUrl_addsSchemeAndApi() {
+		assertEquals("http://localhost:8080/api", sessionStore.normalizeBaseUrl("localhost:8080"));
+	}
+
+	@Test
+	void normalizeBaseUrl_keepsExistingApiPath() {
+		assertEquals("http://localhost:8080/api", sessionStore.normalizeBaseUrl("http://localhost:8080/api"));
+	}
+
+	@Test
+	void normalizeBaseUrl_handlesHttpsAndTrailingSlash() {
+		assertEquals("https://demo.example.com/api", sessionStore.normalizeBaseUrl("https://demo.example.com/"));
+	}
+
+	@Test
+	void normalizeBaseUrl_nullInputStillReturnsApiSuffix() {
+		assertEquals("http:///api", sessionStore.normalizeBaseUrl(null));
+	}
+
+	@Test
+	void load_malformedFileReturnsNull() throws Exception {
+		var sessionFile = tempHome.resolve(".config")
+		                          .resolve("vempain-file-cli")
+		                          .resolve("session.json");
+		Files.createDirectories(sessionFile.getParent());
+		Files.writeString(sessionFile, "not-json", StandardCharsets.UTF_8);
+
+		assertNull(sessionStore.load());
+	}
+
+	@Test
+	void saveLoadAndClear_roundTripWorks() throws Exception {
+		sessionStore.save("localhost:8080", "token-123");
+
+		var loaded = sessionStore.load();
+		assertNotNull(loaded);
+		assertEquals("http://localhost:8080/api", loaded.baseUrl());
+		assertEquals("token-123", loaded.token());
+
+		sessionStore.clear();
+		assertNull(sessionStore.load());
+	}
+}
+

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -47,6 +47,9 @@
 
 - JSON DTOs use **snake_case** through `@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)` in `api/**`; request/response examples should follow
   that. Example: `ScanRequest` expects `original_directory` / `export_directory`.
+- JSON field names are mandatory snake_case for all API contracts in this repo; do not introduce camelCase JSON keys in DTOs, payload examples, or tests.
+- Prefer Jackson v3 `tools.jackson.databind.*` naming/mapper APIs for JSON behavior; keep non-`tools.jackson` annotations only when no `tools.jackson`
+  equivalent exists in active dependencies.
 - Be careful with repo scripts: `scripts/testScanning.sh` still posts `directory_name`, which does not match the current `ScanRequest` fields.
 - Entity-to-API mapping usually lives on the entity itself via `toResponse()` methods (`FileEntity`, `FileGroupEntity`, `GpsLocationEntity`,
   `LocationGuardEntity`, `ExportFileEntity`). Reuse those instead of adding parallel mappers.

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,8 +20,10 @@ swaggerVersion=2.2.48
 springdocVersion=3.0.3
 # https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter
 mockitoVersion=5.23.0
+# https://mvnrepository.com/artifact/org.jline/jline
+jlineVersion=3.30.6
 # https://github.com/Vempain/vempain-auth/packages/2723219
-vempainAuthVersion=1.0.10
+vempainAuthVersion=1.0.11
 # https://github.com/Vempain/vempain-admin-backend/packages/2624185
 vempainAdminVersion=1.0.21
 # https://mvnrepository.com/artifact/commons-codec/commons-codec

--- a/packaging/rpm/vempain-file-cli.spec
+++ b/packaging/rpm/vempain-file-cli.spec
@@ -1,0 +1,38 @@
+Name:           vempain-file-cli
+Version:        0.0.0
+Release:        1%{?dist}
+Summary:        Vempain File backend command-line client
+
+License:        GPL-2.0-only
+URL:            https://github.com/Vempain/vempain-file-backend
+Source0:        %{name}.tar.gz
+
+BuildArch:      noarch
+Requires:       java-25-openjdk-headless
+
+%description
+Command-line utility for the Vempain File backend API.
+
+%prep
+%setup -q
+
+%build
+# No build step here. The reusable workflow injects a prebuilt fat jar
+# into packaging/rpm/vf-cli.jar before rpmbuild runs.
+
+%install
+install -d %{buildroot}/usr/bin
+install -d %{buildroot}/usr/lib/vempain/file
+
+install -m 0755 vf-cli %{buildroot}/usr/bin/vf-cli
+install -m 0644 packaging/rpm/vf-cli.jar %{buildroot}/usr/lib/vempain/file/vf-cli.jar
+
+%files
+%license LICENSE
+/usr/bin/vf-cli
+/usr/lib/vempain/file/vf-cli.jar
+
+%changelog
+* Fri May 15 2026 Vempain CI
+- Initial RPM packaging for vf-cli
+

--- a/service/src/main/java/fi/poltsi/vempain/file/controller/FileContentController.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/controller/FileContentController.java
@@ -1,0 +1,49 @@
+package fi.poltsi.vempain.file.controller;
+
+import fi.poltsi.vempain.file.rest.FileContentAPI;
+import fi.poltsi.vempain.file.service.FileContentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.nio.charset.StandardCharsets;
+
+@RestController
+@RequiredArgsConstructor
+public class FileContentController implements FileContentAPI {
+
+	private final FileContentService fileContentService;
+
+	@Override
+	public ResponseEntity<Resource> getFileContent(long id) {
+		var contentFile = fileContentService.resolveOriginalFile(id);
+		var mediaType   = parseMediaType(contentFile.mimetype());
+		var disposition = ContentDisposition.inline()
+		                                    .filename(contentFile.filename(), StandardCharsets.UTF_8)
+		                                    .build();
+		var resource = new FileSystemResource(contentFile.absolutePath());
+
+		return ResponseEntity.ok()
+		                     .contentType(mediaType)
+		                     .contentLength(contentFile.size())
+		                     .header(HttpHeaders.CONTENT_DISPOSITION, disposition.toString())
+		                     .body(resource);
+	}
+
+	private MediaType parseMediaType(String mimetype) {
+		if (mimetype == null || mimetype.isBlank()) {
+			return MediaType.APPLICATION_OCTET_STREAM;
+		}
+		try {
+			return MediaType.parseMediaType(mimetype);
+		} catch (Exception ignored) {
+			return MediaType.APPLICATION_OCTET_STREAM;
+		}
+	}
+}
+

--- a/service/src/main/java/fi/poltsi/vempain/file/service/FileContentService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/FileContentService.java
@@ -1,0 +1,79 @@
+package fi.poltsi.vempain.file.service;
+
+import fi.poltsi.vempain.file.repository.files.FileRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FileContentService {
+
+	private final FileRepository fileRepository;
+
+	@Value("${vempain.original-root-directory}")
+	private String originalRootDirectory;
+
+	public ContentFile resolveOriginalFile(long fileId) {
+		var entity = fileRepository.findById(fileId)
+		                           .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+		                                                                          "File with id %d not found".formatted(fileId)));
+
+		var rootPath = Paths.get(originalRootDirectory)
+		                    .normalize()
+		                    .toAbsolutePath();
+
+		var relativeDir = normalizeRelativeDirectory(entity.getFilePath());
+		var resolvedPath = rootPath.resolve(relativeDir)
+		                           .resolve(entity.getFilename())
+		                           .normalize();
+
+		if (!resolvedPath.startsWith(rootPath)) {
+			log.warn("Rejected file content request outside original root. fileId={}, path={}", fileId, resolvedPath);
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Resolved file path is outside configured original root");
+		}
+
+		if (!Files.exists(resolvedPath) || !Files.isRegularFile(resolvedPath)) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+			                                  "File content for id %d not found from storage".formatted(fileId));
+		}
+
+		try {
+			return new ContentFile(
+					resolvedPath,
+					entity.getFilename(),
+					entity.getMimetype(),
+					Files.size(resolvedPath)
+			);
+		} catch (IOException e) {
+			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+			                                  "Failed to resolve file size for id %d".formatted(fileId), e);
+		}
+	}
+
+	private String normalizeRelativeDirectory(String filePath) {
+		if (filePath == null || filePath.isBlank() || "/".equals(filePath.trim())) {
+			return "";
+		}
+
+		var normalized = filePath.trim()
+		                         .replace('\\', '/');
+		while (normalized.startsWith("/")) {
+			normalized = normalized.substring(1);
+		}
+		return normalized;
+	}
+
+	public record ContentFile(Path absolutePath, String filename, String mimetype, long size) {
+	}
+}
+

--- a/service/src/test/java/fi/poltsi/vempain/file/controller/files/MusicFileControllerCTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/controller/files/MusicFileControllerCTC.java
@@ -25,7 +25,10 @@ class MusicFileControllerCTC extends AbstractControllerCTC {
 	void findAll_returns200WithValidPageShape() throws Exception {
 		doPost("/files/music/paged", "{\"page\":0,\"size\":10}")
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.content").isArray());
+				.andExpect(jsonPath("$.content").isArray())
+				.andExpect(jsonPath("$.page").exists())
+				.andExpect(jsonPath("$.total_pages").exists())
+				.andExpect(jsonPath("$.total_elements").exists());
 	}
 
 	// -----------------------------------------------------------------------

--- a/service/src/test/java/fi/poltsi/vempain/file/service/FileContentServiceUTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/service/FileContentServiceUTC.java
@@ -1,0 +1,76 @@
+package fi.poltsi.vempain.file.service;
+
+import fi.poltsi.vempain.file.entity.FileEntity;
+import fi.poltsi.vempain.file.repository.files.FileRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class FileContentServiceUTC {
+
+	private final FileRepository     fileRepository = mock(FileRepository.class);
+	private       FileContentService fileContentService;
+
+	@TempDir
+	Path tempDir;
+
+	@BeforeEach
+	void setUp() {
+		fileContentService = new FileContentService(fileRepository);
+		ReflectionTestUtils.setField(fileContentService, "originalRootDirectory", tempDir.toString());
+	}
+
+	@Test
+	void resolveOriginalFile_returnsResolvedFile() throws Exception {
+		var fileDir = tempDir.resolve("audio/test");
+		Files.createDirectories(fileDir);
+		var target = fileDir.resolve("song.txt");
+		Files.writeString(target, "hello world");
+
+		var entity = mock(FileEntity.class);
+		when(entity.getFilePath()).thenReturn("/audio/test");
+		when(entity.getFilename()).thenReturn("song.txt");
+		when(entity.getMimetype()).thenReturn("text/plain");
+		when(fileRepository.findById(1L)).thenReturn(Optional.of(entity));
+
+		var result = fileContentService.resolveOriginalFile(1L);
+
+		assertThat(result.absolutePath()).isEqualTo(target);
+		assertThat(result.filename()).isEqualTo("song.txt");
+		assertThat(result.mimetype()).isEqualTo("text/plain");
+		assertThat(result.size()).isEqualTo(11L);
+	}
+
+	@Test
+	void resolveOriginalFile_missingEntity_throwsNotFound() {
+		when(fileRepository.findById(2L)).thenReturn(Optional.empty());
+
+		var ex = assertThrows(ResponseStatusException.class, () -> fileContentService.resolveOriginalFile(2L));
+		assertThat(ex.getStatusCode()
+		             .value()).isEqualTo(404);
+	}
+
+	@Test
+	void resolveOriginalFile_pathTraversal_throwsBadRequest() {
+		var entity = mock(FileEntity.class);
+		when(entity.getFilePath()).thenReturn("/../../etc");
+		when(entity.getFilename()).thenReturn("passwd");
+		when(fileRepository.findById(3L)).thenReturn(Optional.of(entity));
+
+		var ex = assertThrows(ResponseStatusException.class, () -> fileContentService.resolveOriginalFile(3L));
+		assertThat(ex.getStatusCode()
+		             .value()).isEqualTo(400);
+	}
+}
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
 rootProject.name = 'vempain-file-backend'
-include 'api', 'service'
+include 'api', 'service', 'cli'

--- a/vf-cli
+++ b/vf-cli
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+JAR_PATH="/usr/lib/vempain/file/vf-cli.jar"
+
+if ! command -v java >/dev/null 2>&1; then
+	echo "Error: java runtime not found in PATH" >&2
+	exit 127
+fi
+
+if [[ ! -f "$JAR_PATH" ]]; then
+	echo "Error: CLI jar not found at $JAR_PATH" >&2
+	exit 1
+fi
+
+exec java -jar "$JAR_PATH" "$@"
+


### PR DESCRIPTION
This pull request introduces a new command-line interface (CLI) module for the Vempain File backend, along with supporting infrastructure and documentation. It also adds a new API interface for file content retrieval and clarifies JSON conventions in the documentation. The most important changes are grouped below.

**New CLI Module:**

* Added the `cli` module, including a `build.gradle` for building, testing, coverage, and fat jar packaging. The CLI supports login, file listing and retrieval, publishing, scanning, and an interactive shell.
* Implemented `BackendClient` and `SessionStore` classes for backend API communication and session management, including local JWT storage and normalization of backend URLs. [[1]](diffhunk://#diff-b9fe1295d71d7d04e49e90bd51a1365633d4d15a70b094ca6a28b686360ddc27R1-R102) [[2]](diffhunk://#diff-f13683251aa912d95022f7338aa8eb295a9d0ce76dd0dd936e9d7d9617723eeeR1-R67)
* Added comprehensive CLI usage documentation in `cli/README.md`, describing features, build/run instructions, and session storage location.
* Provided unit tests for the CLI backend client, covering login, JSON and byte retrieval, error handling, and session scenarios.

**API Enhancements:**

* Introduced the `FileContentAPI` interface for streaming original file bytes by file ID, with OpenAPI annotations for documentation and security.

**Documentation & Conventions:**

* Updated `AGENTS.md` to clarify that all API JSON contracts must use snake_case, and to prefer Jackson v3 APIs for JSON configuration.