### PR TITLE
Set Java 25 as dependency version in the cli rpm package

### DIFF
--- a/.github/workflows/rpm-cli.yaml
+++ b/.github/workflows/rpm-cli.yaml
@@ -20,7 +20,7 @@ jobs:
       spec_file: 'packaging/rpm/vempain-file-cli.spec'
       source_jar_path: 'packaging/rpm/vf-cli.jar'
       wrapper_script_path: 'vf-cli'
-      jre_package: 'java-21-openjdk-headless'
+      jre_package: 'java-25-openjdk-headless'
       artifact_name: 'vempain-file-cli-rpm'
     secrets: inherit
 


### PR DESCRIPTION
This pull request updates the RPM packaging workflow to use a newer Java runtime. The only change is updating the Java Runtime Environment (JRE) dependency from Java 21 to Java 25 in the `.github/workflows/rpm-cli.yaml` file.

- Updated the `jre_package` for the RPM build workflow from `java-21-openjdk-headless` to `java-25-openjdk-headless` to ensure the application is built with the latest supported Java version.