### PR TITLE
Update workflow script providing write-permission

### DIFF
--- a/.github/workflows/rpm-cli.yaml
+++ b/.github/workflows/rpm-cli.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   packages: read
 
 jobs:


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow permissions. The change grants write access to repository contents, which may be needed for certain workflow steps.