### PR TITLE
Add tab completion to cli

### DIFF
--- a/cli/src/main/java/fi/poltsi/vempain/file/cli/VempainFileCliApplication.java
+++ b/cli/src/main/java/fi/poltsi/vempain/file/cli/VempainFileCliApplication.java
@@ -12,7 +12,6 @@ import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
 import org.jline.reader.ParsedLine;
 import org.jline.reader.UserInterruptException;
-import org.jline.reader.impl.completer.StringsCompleter;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -21,8 +20,10 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -35,10 +36,18 @@ public class VempainFileCliApplication {
 	                                                    .map(t -> t.shortName)
 	                                                    .collect(Collectors.toSet());
 
+	private static final List<String>              BASE_COMMANDS   = List.of(
+			"login", "files-list", "file-show", "publish-music", "publish-gps", "scan", "logout", "shell", "exit", "quit"
+	);
+	private static final Map<String, List<String>> COMMAND_OPTIONS = commandOptions();
+
 	private final SessionStore  sessionStore;
 	private final BackendClient backendClient;
 	private final PrintStream   out;
 	private final PrintStream   err;
+
+	private boolean shellMode;
+	private boolean debugCompletion;
 
 	public VempainFileCliApplication() {
 		this(new SessionStore(), new BackendClient(), System.out, System.err);
@@ -51,7 +60,7 @@ public class VempainFileCliApplication {
 		this.err           = err;
 	}
 
-	public static void main(String[] args) {
+	static void main(String[] args) {
 		new VempainFileCliApplication().run(args);
 	}
 
@@ -103,6 +112,10 @@ public class VempainFileCliApplication {
 			return;
 		}
 
+		if (root.debugCompletion || isEnvDebugCompletionEnabled()) {
+			debugCompletion = true;
+		}
+
 		try {
 			switch (command) {
 				case "login" -> login(login);
@@ -112,7 +125,12 @@ public class VempainFileCliApplication {
 				case "publish-gps" -> publishGps(publishGps);
 				case "scan" -> scan(scan);
 				case "logout" -> logout();
-				case "shell" -> shell();
+				case "shell" -> {
+					if (shellMode) {
+						throw new IllegalStateException("Already in shell-mode.");
+					}
+					shell();
+				}
 				default -> jc.usage();
 			}
 		} catch (Exception e) {
@@ -247,32 +265,37 @@ public class VempainFileCliApplication {
 
 	private void shell() {
 		var reader = LineReaderBuilder.builder()
-		                              .completer(new CliCompleter())
+		                              .completer(new CliCompleter(true))
 		                              .build();
 		runShell(reader);
 	}
 
 	void runShell(LineReader reader) {
-		out.println("Interactive shell started. Type 'exit' to quit.");
-
-		while (true) {
-			try {
-				var line = reader.readLine("vempain-file> ");
-				if (line == null) {
-					continue;
-				}
-				var trimmed = line.trim();
-				if (trimmed.isEmpty()) {
-					continue;
-				}
-				if ("exit".equalsIgnoreCase(trimmed) || "quit".equalsIgnoreCase(trimmed)) {
+		var previousShellMode = shellMode;
+		shellMode = true;
+		try {
+			out.println("Interactive shell started. Type 'exit' to quit.");
+			while (true) {
+				try {
+					var line = reader.readLine("vempain-file> ");
+					if (line == null) {
+						continue;
+					}
+					var trimmed = line.trim();
+					if (trimmed.isEmpty()) {
+						continue;
+					}
+					if ("exit".equalsIgnoreCase(trimmed) || "quit".equalsIgnoreCase(trimmed)) {
+						break;
+					}
+					run(splitArgs(trimmed));
+				} catch (UserInterruptException ignored) {
+				} catch (EndOfFileException ignored) {
 					break;
 				}
-				run(splitArgs(trimmed));
-			} catch (UserInterruptException ignored) {
-			} catch (EndOfFileException ignored) {
-				break;
 			}
+		} finally {
+			shellMode = previousShellMode;
 		}
 	}
 
@@ -345,14 +368,19 @@ public class VempainFileCliApplication {
 
 	private class CliCompleter implements Completer {
 
-		private final StringsCompleter commandCompleter = new StringsCompleter(
-				"login", "files-list", "file-show", "publish-music", "publish-gps", "scan", "logout", "shell", "exit", "quit"
-		);
+		private final boolean shellCompleterMode;
+
+		private CliCompleter(boolean shellCompleterMode) {
+			this.shellCompleterMode = shellCompleterMode;
+		}
 
 		@Override
 		public void complete(LineReader reader, ParsedLine line, List<Candidate> candidates) {
+			var currentWord = line.word() == null ? "" : line.word();
+			debug("input line='" + line.line() + "' wordIndex=" + line.wordIndex() + " currentWord='" + currentWord + "'");
 			if (line.wordIndex() == 0) {
-				commandCompleter.complete(reader, line, candidates);
+				completeCommands(currentWord, candidates);
+				debugCandidates(currentWord, candidates);
 				return;
 			}
 
@@ -362,7 +390,9 @@ public class VempainFileCliApplication {
 			}
 			var command = words.get(0);
 
-			if (("files-list".equals(command) || "file-show".equals(command)) && wantsTypeCompletion(words, line.wordIndex())) {
+			completeCommandOptions(command, words, line.wordIndex(), currentWord, candidates);
+
+			if ((("files-list".equals(command) || "file-show".equals(command)) && wantsTypeCompletion(words, line.wordIndex()))) {
 				FILE_TYPES.stream()
 				          .sorted()
 				          .forEach(type -> candidates.add(new Candidate(type)));
@@ -370,7 +400,43 @@ public class VempainFileCliApplication {
 			}
 
 			if ("scan".equals(command)) {
-				completeScanPath(words, line.wordIndex(), candidates, line.word());
+				completeScanPath(words, line.wordIndex(), candidates, currentWord);
+			}
+			debugCandidates(currentWord, candidates);
+		}
+
+		private void completeCommands(String currentWord, List<Candidate> candidates) {
+			for (var command : BASE_COMMANDS) {
+				if (shellCompleterMode && "shell".equals(command)) {
+					continue;
+				}
+				if (currentWord.isBlank() || command.startsWith(currentWord)) {
+					candidates.add(new Candidate(command));
+				}
+			}
+		}
+
+		private void completeCommandOptions(String command, List<String> words, int wordIndex, String currentWord, List<Candidate> candidates) {
+			if ("exit".equals(command) || "quit".equals(command)) {
+				return;
+			}
+			var options = COMMAND_OPTIONS.get(command);
+			if (options == null || options.isEmpty()) {
+				return;
+			}
+
+			var previous = wordIndex > 0 ? words.get(Math.max(0, wordIndex - 1)) : "";
+			boolean suggest = (wordIndex == 1 && (currentWord.isBlank() || currentWord.startsWith("-")))
+			                  || currentWord.startsWith("-")
+			                  || "--".equals(previous) || "-".equals(previous);
+			if (!suggest) {
+				return;
+			}
+
+			for (var option : options) {
+				if (currentWord.isBlank() || option.startsWith(currentWord)) {
+					candidates.add(new Candidate(option));
+				}
 			}
 		}
 
@@ -386,13 +452,8 @@ public class VempainFileCliApplication {
 			if (wordIndex <= 0) {
 				return;
 			}
-			var    previous = words.get(Math.max(0, wordIndex - 1));
-			String completionType;
-			if ("--original-directory".equals(previous) || "-o".equals(previous)) {
-				completionType = "ORIGINAL";
-			} else if ("--export-directory".equals(previous) || "-e".equals(previous)) {
-				completionType = "EXPORTED";
-			} else {
+			var completionType = resolveScanCompletionType(words, wordIndex, currentWord);
+			if (completionType == null) {
 				return;
 			}
 
@@ -401,30 +462,174 @@ public class VempainFileCliApplication {
 				return;
 			}
 
-			var path    = (currentWord == null || currentWord.isBlank()) ? "/" : currentWord;
+			var path = buildPathQuery(words, wordIndex, currentWord);
 			var request = new JSONObject().put("path", path)
 			                              .put("type", completionType);
+			debug("path-completion request: " + request);
 			try {
 				var response    = backendClient.postJson(session, "/path-completion", request);
 				var completions = response.optJSONArray("completions");
+				debug("path-completion response: " + response);
 				if (completions == null) {
 					return;
 				}
+				var uniqueMatch = completions.length() == 1;
+				var hasPathPrefixToken = currentWord != null
+				                         && !currentWord.startsWith("/")
+				                         && wordIndex > 0
+				                         && words.get(wordIndex - 1)
+				                                 .startsWith("/");
+				var pathPrefixToken = hasPathPrefixToken ? words.get(wordIndex - 1) : "";
+				var queryBasePath   = basePathForQuery(path);
 				for (int i = 0; i < completions.length(); i++) {
-					candidates.add(new Candidate(completions.getString(i)));
+					var completion     = ensureDirectorySuffix(normalizeCompletionPath(completions.getString(i), queryBasePath));
+					var candidateValue = completion;
+					if (hasPathPrefixToken && completion.startsWith(pathPrefixToken)) {
+						candidateValue = completion.substring(pathPrefixToken.length());
+					}
+					candidates.add(new Candidate(candidateValue, completion, null, null, null, null, false));
+				}
+				if (uniqueMatch && completions.length() == 1) {
+					var target = ensureDirectorySuffix(normalizeCompletionPath(completions.getString(0), queryBasePath));
+					var applied = (hasPathPrefixToken && target.startsWith(pathPrefixToken))
+					              ? target.substring(pathPrefixToken.length()) : target;
+					debug("apply decision: would replace '" + currentWord + "' with '" + applied + "'");
 				}
 			} catch (Exception ignored) {
+			}
+		}
+
+		private String resolveScanCompletionType(List<String> words, int wordIndex, String currentWord) {
+			if (currentWord != null && currentWord.startsWith("-")) {
+				return null;
+			}
+
+			for (int i = wordIndex - 1; i >= 1; i--) {
+				var token = words.get(i);
+				if ("--original-directory".equals(token) || "-o".equals(token)) {
+					return "ORIGINAL";
+				}
+				if ("--export-directory".equals(token) || "-e".equals(token)) {
+					return "EXPORTED";
+				}
+				if (token.startsWith("-")) {
+					return null;
+				}
+			}
+			return null;
+		}
+
+		private String buildPathQuery(List<String> words, int wordIndex, String currentWord) {
+			if (currentWord == null || currentWord.isBlank()) {
+				return "/";
+			}
+			if (currentWord.startsWith("/")) {
+				return currentWord;
+			}
+			if (wordIndex > 0) {
+				var previous = words.get(wordIndex - 1);
+				if (previous.startsWith("/")) {
+					return previous + currentWord;
+				}
+			}
+			return currentWord;
+		}
+
+		private String ensureDirectorySuffix(String completion) {
+			if (completion == null || completion.isBlank() || completion.endsWith("/")) {
+				return completion;
+			}
+			return completion + "/";
+		}
+
+		private String basePathForQuery(String queryPath) {
+			if (queryPath == null || queryPath.isBlank() || "/".equals(queryPath)) {
+				return "/";
+			}
+			if (queryPath.endsWith("/")) {
+				return queryPath;
+			}
+			var lastSlash = queryPath.lastIndexOf('/');
+			if (lastSlash < 0) {
+				return "/";
+			}
+			if (lastSlash == 0) {
+				return "/";
+			}
+			return queryPath.substring(0, lastSlash + 1);
+		}
+
+		private String normalizeCompletionPath(String rawCompletion, String queryBasePath) {
+			if (rawCompletion == null || rawCompletion.isBlank()) {
+				return rawCompletion;
+			}
+			var base = (queryBasePath == null || queryBasePath.isBlank()) ? "/" : queryBasePath;
+			if (rawCompletion.startsWith(base)) {
+				return rawCompletion;
+			}
+			if (rawCompletion.startsWith("/")) {
+				if ("/".equals(base)) {
+					return rawCompletion;
+				}
+				return base + rawCompletion.substring(1);
+			}
+			if ("/".equals(base)) {
+				return "/" + rawCompletion;
+			}
+			return base + rawCompletion;
+		}
+
+		private void debugCandidates(String currentWord, List<Candidate> candidates) {
+			if (!debugCompletion) {
+				return;
+			}
+			var values = candidates.stream()
+			                       .map(Candidate::value)
+			                       .collect(Collectors.joining(", "));
+			debug("suggestions for '" + currentWord + "': [" + values + "]");
+		}
+
+		private void debug(String message) {
+			if (debugCompletion) {
+				err.println("[completion-debug] " + message);
 			}
 		}
 	}
 
 	Completer createCompleterForTests() {
-		return new CliCompleter();
+		return new CliCompleter(false);
+	}
+
+	Completer createShellCompleterForTests() {
+		return new CliCompleter(true);
+	}
+
+	private boolean isEnvDebugCompletionEnabled() {
+		var env = System.getenv("VEMPAIN_CLI_DEBUG_COMPLETION");
+		if (env == null) {
+			return false;
+		}
+		return "1".equals(env) || "true".equalsIgnoreCase(env) || "yes".equalsIgnoreCase(env);
+	}
+
+	private static Map<String, List<String>> commandOptions() {
+		var options = new LinkedHashMap<String, List<String>>();
+		options.put("login", List.of("--url", "--username", "--password"));
+		options.put("files-list", List.of("-t", "--type", "-p", "--page", "-s", "--size", "--sort-by", "--direction", "--search", "--case-sensitive"));
+		options.put("file-show", List.of("-t", "--type", "-i", "--id", "--raw", "--content-limit"));
+		options.put("publish-music", List.of());
+		options.put("publish-gps", List.of("--file-group-id", "--time-series-name"));
+		options.put("scan", List.of("-o", "--original-directory", "-e", "--export-directory"));
+		options.put("logout", List.of());
+		options.put("shell", List.of());
+		return options;
 	}
 
 	private static class RootArgs {
 		@Parameter(names = {"-h", "--help"}, help = true, description = "Show help")
 		boolean help;
+		@Parameter(names = {"--debug-completion"}, description = "Enable shell completion debug logging")
+		boolean debugCompletion;
 	}
 
 	@Parameters(commandDescription = "Authenticate and store session")

--- a/cli/src/main/java/fi/poltsi/vempain/file/cli/VempainFileCliApplication.java
+++ b/cli/src/main/java/fi/poltsi/vempain/file/cli/VempainFileCliApplication.java
@@ -352,7 +352,7 @@ public class VempainFileCliApplication {
 
 	private String[] splitArgs(String commandLine) {
 		List<String> tokens  = new ArrayList<>();
-		Matcher      matcher = Pattern.compile("\\\"([^\\\"]*)\\\"|'([^']*)'|(\\S+)")
+		Matcher matcher = Pattern.compile("\"([^\"]*)\"|'([^']*)'|(\\S+)")
 		                              .matcher(commandLine);
 		while (matcher.find()) {
 			if (matcher.group(1) != null) {
@@ -388,7 +388,7 @@ public class VempainFileCliApplication {
 			if (words.isEmpty()) {
 				return;
 			}
-			var command = words.get(0);
+			var command = words.getFirst();
 
 			completeCommandOptions(command, words, line.wordIndex(), currentWord, candidates);
 
@@ -466,6 +466,7 @@ public class VempainFileCliApplication {
 			var request = new JSONObject().put("path", path)
 			                              .put("type", completionType);
 			debug("path-completion request: " + request);
+
 			try {
 				var response    = backendClient.postJson(session, "/path-completion", request);
 				var completions = response.optJSONArray("completions");
@@ -481,6 +482,7 @@ public class VempainFileCliApplication {
 				                                 .startsWith("/");
 				var pathPrefixToken = hasPathPrefixToken ? words.get(wordIndex - 1) : "";
 				var queryBasePath   = basePathForQuery(path);
+
 				for (int i = 0; i < completions.length(); i++) {
 					var completion     = ensureDirectorySuffix(normalizeCompletionPath(completions.getString(i), queryBasePath));
 					var candidateValue = completion;
@@ -489,6 +491,7 @@ public class VempainFileCliApplication {
 					}
 					candidates.add(new Candidate(candidateValue, completion, null, null, null, null, false));
 				}
+
 				if (uniqueMatch && completions.length() == 1) {
 					var target = ensureDirectorySuffix(normalizeCompletionPath(completions.getString(0), queryBasePath));
 					var applied = (hasPathPrefixToken && target.startsWith(pathPrefixToken))

--- a/cli/src/test/java/fi/poltsi/vempain/file/cli/CliIntegrationUTC.java
+++ b/cli/src/test/java/fi/poltsi/vempain/file/cli/CliIntegrationUTC.java
@@ -6,16 +6,23 @@ import com.sun.net.httpserver.HttpServer;
 import org.jline.reader.Candidate;
 import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
 import org.jline.reader.ParsedLine;
+import org.jline.reader.impl.LineReaderImpl;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.utils.ClosedException;
+import org.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Proxy;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
@@ -23,8 +30,13 @@ import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CliIntegrationUTC {
@@ -83,7 +95,6 @@ class CliIntegrationUTC {
 			                    .contains("Error:"));
 		}
 	}
-
 	@Test
 	void fileShow_supportsContentLimitAndRaw() throws Exception {
 		try (var server = new MockApiServer()) {
@@ -119,11 +130,12 @@ class CliIntegrationUTC {
 			assertTrue(rawOutput.contains("abcdefghijklmnopqrstuvwxyz"));
 		}
 	}
-
 	@Test
 	void shellCompletion_completesFileTypeAndPath() throws Exception {
 		try (var server = new MockApiServer()) {
-			server.registerJson("/api/path-completion", "{\"completions\":[\"/music\",\"/museum\"]}");
+			server.registerPathCompletionByPath(Map.of(
+					"/mu", "{\"completions\":[\"/music\",\"/museum\"]}"
+			));
 
 			var sessionStore = new SessionStore();
 			sessionStore.save(server.baseUrl(), "jwt-3");
@@ -139,7 +151,100 @@ class CliIntegrationUTC {
 			var pathCandidates = new ArrayList<Candidate>();
 			completer.complete(null, new StubParsedLine(List.of("scan", "--original-directory", "/mu"), 2, "/mu"), pathCandidates);
 			assertTrue(pathCandidates.stream()
-			                         .anyMatch(c -> "/music".equals(c.value())));
+			                         .anyMatch(c -> "/music/".equals(c.value())));
+		}
+	}
+
+	@Test
+	void shellCompletion_scanPathCompletion_uniqueDirectory_doesNotAppendSpace() throws Exception {
+		try (var server = new MockApiServer()) {
+			server.registerPathCompletionByPath(Map.of(
+					"/m", "{\"completions\":[\"/music\"]}"
+			));
+
+			var sessionStore = new SessionStore();
+			sessionStore.save(server.baseUrl(), "jwt-3a");
+
+			var app       = new VempainFileCliApplication(sessionStore, new BackendClient(), System.out, System.err);
+			var completer = app.createShellCompleterForTests();
+
+			var candidates = new ArrayList<Candidate>();
+			completer.complete(null, new StubParsedLine(List.of("scan", "-o", "/m"), 2, "/m"), candidates);
+
+			assertEquals(1, candidates.size());
+			assertEquals("/music/", candidates.get(0)
+			                                  .value());
+			assertNull(candidates.get(0)
+			                     .suffix());
+			assertFalse(candidates.get(0)
+			                      .complete());
+		}
+	}
+
+	@Test
+	void shellCompletion_scanPathCompletion_supportsNestedDirectories() throws Exception {
+		try (var server = new MockApiServer()) {
+			server.registerPathCompletionByPath(Map.of(
+					"/mu", "{\"completions\":[\"/music\",\"/museum\"]}",
+					"/music/", "{\"completions\":[\"/music/Aavikko\",\"/music/Abbath\"]}"
+			));
+
+			var sessionStore = new SessionStore();
+			sessionStore.save(server.baseUrl(), "jwt-3b");
+
+			var app       = new VempainFileCliApplication(sessionStore, new BackendClient(), System.out, System.err);
+			var completer = app.createShellCompleterForTests();
+
+			var firstLevel = new ArrayList<Candidate>();
+			completer.complete(null, new StubParsedLine(List.of("scan", "-o", "/mu"), 2, "/mu"), firstLevel);
+			assertTrue(firstLevel.stream()
+			                     .anyMatch(c -> "/music/".equals(c.value())));
+
+			var secondLevel = new ArrayList<Candidate>();
+			completer.complete(null, new StubParsedLine(List.of("scan", "-o", "/music/"), 2, "/music/"), secondLevel);
+			assertTrue(secondLevel.stream()
+			                      .anyMatch(c -> "/music/Aavikko/".equals(c.value())));
+			assertTrue(secondLevel.stream()
+			                      .anyMatch(c -> "/music/Abbath/".equals(c.value())));
+		}
+	}
+
+	@Test
+	void shellCompletion_scanPathCompletion_explicitThreeStepSequence_regression() throws Exception {
+		try (var server = new MockApiServer()) {
+			server.registerPathCompletionByPath(Map.of(
+					"/", "{\"completions\":[\"/archive\",\"/music\",\"/video\"]}",
+					"/m", "{\"completions\":[\"/music\"]}",
+					"/music/", "{\"completions\":[\"/music/Aavikko\",\"/music/Green_Day\"]}"
+			));
+
+			var sessionStore = new SessionStore();
+			sessionStore.save(server.baseUrl(), "jwt-3seq");
+
+			var app       = new VempainFileCliApplication(sessionStore, new BackendClient(), System.out, System.err);
+			var completer = app.createShellCompleterForTests();
+
+			var rootCandidates = new ArrayList<Candidate>();
+			completer.complete(null, new StubParsedLine(List.of("scan", "-o", ""), 2, ""), rootCandidates);
+			assertTrue(rootCandidates.stream()
+			                         .anyMatch(c -> "/archive/".equals(c.value())));
+			assertTrue(rootCandidates.stream()
+			                         .anyMatch(c -> "/music/".equals(c.value())));
+			assertTrue(rootCandidates.stream()
+			                         .anyMatch(c -> "/video/".equals(c.value())));
+
+			var narrowedCandidates = new ArrayList<Candidate>();
+			completer.complete(null, new StubParsedLine(List.of("scan", "-o", "/m"), 2, "/m"), narrowedCandidates);
+			assertEquals(1, narrowedCandidates.size());
+			assertEquals("/music/", narrowedCandidates.get(0)
+			                                          .value());
+
+			var childCandidates = new ArrayList<Candidate>();
+			completer.complete(null, new StubParsedLine(List.of("scan", "-o", "/music/"), 2, "/music/"), childCandidates);
+			assertTrue(childCandidates.stream()
+			                          .anyMatch(c -> "/music/Aavikko/".equals(c.value())));
+			assertTrue(childCandidates.stream()
+			                          .anyMatch(c -> "/music/Green_Day/".equals(c.value())));
 		}
 	}
 
@@ -167,7 +272,7 @@ class CliIntegrationUTC {
 			assertTrue(output.contains("gps_timeseries_demo"));
 			assertTrue(output.contains("newFilesCount"));
 			assertTrue(output.contains("Session removed."));
-			assertTrue(sessionStore.load() == null);
+			assertNull(sessionStore.load());
 			assertTrue(errBytes.toString(StandardCharsets.UTF_8)
 			                   .isBlank());
 		}
@@ -303,6 +408,106 @@ class CliIntegrationUTC {
 		}
 	}
 
+	@Test
+	void shellCompletion_suggestsCommandOptions() {
+		var app       = new VempainFileCliApplication(new SessionStore(), new BackendClient(), System.out, System.err);
+		var completer = app.createShellCompleterForTests();
+
+		var scanOptionCandidates = new ArrayList<Candidate>();
+		completer.complete(null, new StubParsedLine(List.of("scan", ""), 1, ""), scanOptionCandidates);
+		assertTrue(scanOptionCandidates.stream()
+		                               .anyMatch(c -> "--original-directory".equals(c.value())));
+		assertTrue(scanOptionCandidates.stream()
+		                               .anyMatch(c -> "--export-directory".equals(c.value())));
+
+		var loginOptionCandidates = new ArrayList<Candidate>();
+		completer.complete(null, new StubParsedLine(List.of("login", "--u"), 1, "--u"), loginOptionCandidates);
+		assertTrue(loginOptionCandidates.stream()
+		                                .anyMatch(c -> "--url".equals(c.value())));
+		assertTrue(loginOptionCandidates.stream()
+		                                .anyMatch(c -> "--username".equals(c.value())));
+	}
+
+	@Test
+	void shellModeCommandCompletion_excludesShellCommand() {
+		var app        = new VempainFileCliApplication(new SessionStore(), new BackendClient(), System.out, System.err);
+		var completer  = app.createShellCompleterForTests();
+		var candidates = new ArrayList<Candidate>();
+
+		completer.complete(null, new StubParsedLine(List.of(""), 0, ""), candidates);
+
+		assertFalse(candidates.stream()
+		                      .anyMatch(c -> "shell".equals(c.value())));
+		assertTrue(candidates.stream()
+		                     .anyMatch(c -> "scan".equals(c.value())));
+	}
+
+	@Test
+	void runShell_rejectsNestedShellCommand() {
+		var outBytes = new ByteArrayOutputStream();
+		var errBytes = new ByteArrayOutputStream();
+		var app      = new VempainFileCliApplication(new SessionStore(), new BackendClient(), new PrintStream(outBytes), new PrintStream(errBytes));
+
+		var inputs = new ArrayDeque<String>();
+		inputs.add("shell");
+		inputs.add("exit");
+		LineReader reader = (LineReader) Proxy.newProxyInstance(
+				LineReader.class.getClassLoader(),
+				new Class[]{LineReader.class},
+				(proxy, method, args) -> {
+					if ("readLine".equals(method.getName())) {
+						var next = inputs.poll();
+						if (next == null) {
+							throw new EndOfFileException();
+						}
+						return next;
+					}
+					if (method.getReturnType()
+					          .equals(boolean.class)) {
+						return false;
+					}
+					if (method.getReturnType()
+					          .equals(int.class)) {
+						return 0;
+					}
+					return null;
+				}
+		);
+
+		app.runShell(reader);
+		assertTrue(errBytes.toString(StandardCharsets.UTF_8)
+		                   .contains("Already in shell-mode"));
+	}
+
+	@Test
+	void shellCompletion_optionSets_areExactPerCommand() {
+		var app       = new VempainFileCliApplication(new SessionStore(), new BackendClient(), System.out, System.err);
+		var completer = app.createShellCompleterForTests();
+
+		assertEquals(Set.of("--url", "--username", "--password"),
+		             optionValues(completer, "login"));
+		assertEquals(Set.of("-t", "--type", "-p", "--page", "-s", "--size", "--sort-by", "--direction", "--search", "--case-sensitive"),
+		             optionValues(completer, "files-list"));
+		assertEquals(Set.of("-t", "--type", "-i", "--id", "--raw", "--content-limit"),
+		             optionValues(completer, "file-show"));
+		assertEquals(Set.of(), optionValues(completer, "publish-music"));
+		assertEquals(Set.of("--file-group-id", "--time-series-name"),
+		             optionValues(completer, "publish-gps"));
+		assertEquals(Set.of("-o", "--original-directory", "-e", "--export-directory"),
+		             optionValues(completer, "scan"));
+		assertEquals(Set.of(), optionValues(completer, "logout"));
+		assertEquals(Set.of(), optionValues(completer, "exit"));
+		assertEquals(Set.of(), optionValues(completer, "quit"));
+	}
+
+	private Set<String> optionValues(org.jline.reader.Completer completer, String command) {
+		var candidates = new ArrayList<Candidate>();
+		completer.complete(null, new StubParsedLine(List.of(command, ""), 1, ""), candidates);
+		return candidates.stream()
+		                 .map(Candidate::value)
+		                 .collect(Collectors.toSet());
+	}
+
 	private static class StubParsedLine implements ParsedLine {
 		private final List<String> words;
 		private final int          wordIndex;
@@ -375,6 +580,23 @@ class CliIntegrationUTC {
 			});
 		}
 
+		private void registerPathCompletionByPath(Map<String, String> responsesByPath) {
+			server.createContext("/api/path-completion", exchange -> {
+				var requestBody  = new String(exchange.getRequestBody()
+				                                      .readAllBytes(), StandardCharsets.UTF_8);
+				var requestJson  = new JSONObject(requestBody.isBlank() ? "{}" : requestBody);
+				var path         = requestJson.optString("path", "");
+				var responseBody = responsesByPath.getOrDefault(path, "{\"completions\":[]}");
+				var bytes        = responseBody.getBytes(StandardCharsets.UTF_8);
+				exchange.getResponseHeaders()
+				        .add("Content-Type", "application/json");
+				exchange.sendResponseHeaders(200, bytes.length);
+				try (OutputStream os = exchange.getResponseBody()) {
+					os.write(bytes);
+				}
+			});
+		}
+
 		private String baseUrl() {
 			return "http://localhost:" + server.getAddress()
 			                                   .getPort() + "/api";
@@ -385,5 +607,145 @@ class CliIntegrationUTC {
 			server.stop(0);
 		}
 	}
-}
 
+	@Test
+	void shellCompletion_scanPathCompletion_uniqueMatch_isCompletableWithoutSpaceSuffix() throws Exception {
+		try (var server = new MockApiServer()) {
+			server.registerPathCompletionByPath(Map.of(
+					"/music/G", "{\"completions\":[\"/Green_Day\"]}"
+			));
+
+			var sessionStore = new SessionStore();
+			sessionStore.save(server.baseUrl(), "jwt-3c");
+
+			var app       = new VempainFileCliApplication(sessionStore, new BackendClient(), System.out, System.err);
+			var completer = app.createShellCompleterForTests();
+
+			var candidates = new ArrayList<Candidate>();
+			completer.complete(null, new StubParsedLine(List.of("scan", "--original-directory", "/music/G"), 2, "/music/G"), candidates);
+
+			assertEquals(1, candidates.size());
+			assertEquals("/music/Green_Day/", candidates.get(0)
+			                                            .value());
+			assertFalse(candidates.get(0)
+			                      .complete());
+			assertNull(candidates.get(0)
+			                     .suffix());
+		}
+	}
+
+	@Test
+	void shellCompletion_scanPathCompletion_continuesWhenPathWasSplitBySpace() throws Exception {
+		try (var server = new MockApiServer()) {
+			server.registerPathCompletionByPath(Map.of(
+					"/music/G", "{\"completions\":[\"/Green_Day\"]}"
+			));
+
+			var sessionStore = new SessionStore();
+			sessionStore.save(server.baseUrl(), "jwt-3d");
+
+			var app       = new VempainFileCliApplication(sessionStore, new BackendClient(), System.out, System.err);
+			var completer = app.createShellCompleterForTests();
+
+			var candidates = new ArrayList<Candidate>();
+			completer.complete(null, new StubParsedLine(List.of("scan", "--original-directory", "/music/", "G"), 3, "G"), candidates);
+
+			assertEquals(1, candidates.size());
+			assertEquals("Green_Day/", candidates.get(0)
+			                                     .value());
+			assertNull(candidates.get(0)
+			                     .suffix());
+		}
+	}
+
+	@Test
+	void shellCompletion_realLineReader_appliesExpectedBufferTextOnTab() throws Exception {
+		try (var server = new MockApiServer()) {
+			server.registerPathCompletionByPath(Map.of(
+					"/m", "{\"completions\":[\"/music\"]}",
+					"/music/G", "{\"completions\":[\"/Green_Day\"]}",
+					"/music/", "{\"completions\":[\"/music/Aavikko\",\"/music/Green_Day\"]}"
+			));
+			var sessionStore = new SessionStore();
+			sessionStore.save(server.baseUrl(), "jwt-3e");
+			var app = new VempainFileCliApplication(sessionStore, new BackendClient(), System.out, System.err);
+
+			try (var terminal = TerminalBuilder.builder()
+			                                   .dumb(true)
+			                                   .streams(new ByteArrayInputStream(new byte[0]), new ByteArrayOutputStream())
+			                                   .build()) {
+				var reader = (LineReaderImpl) LineReaderBuilder.builder()
+				                                               .terminal(terminal)
+				                                               .completer(app.createShellCompleterForTests())
+				                                               .build();
+				reader.setKeyMap(LineReader.MAIN);
+
+				var setBuffer = LineReaderImpl.class.getDeclaredMethod("setBuffer", String.class);
+				setBuffer.setAccessible(true);
+				var completionTypeClass = Class.forName("org.jline.reader.impl.LineReaderImpl$CompletionType");
+				@SuppressWarnings("unchecked")
+				var completeType = Enum.valueOf((Class<Enum>) completionTypeClass, "Complete");
+				var doComplete = LineReaderImpl.class.getDeclaredMethod("doComplete", completionTypeClass, boolean.class, boolean.class, boolean.class);
+				doComplete.setAccessible(true);
+
+				setBuffer.invoke(reader, "scan -o /m");
+				invokeCompletion(doComplete, reader, completeType);
+				assertEquals("scan -o /music/", reader.getBuffer()
+				                                      .toString());
+
+				setBuffer.invoke(reader, "scan -o /music/");
+				invokeCompletion(doComplete, reader, completeType);
+				assertEquals("scan -o /music/", reader.getBuffer()
+				                                      .toString());
+
+				setBuffer.invoke(reader, "scan -o /music/G");
+				invokeCompletion(doComplete, reader, completeType);
+				assertEquals("scan -o /music/Green_Day/", reader.getBuffer()
+				                                                .toString());
+			}
+		}
+	}
+
+	private void invokeCompletion(java.lang.reflect.Method doComplete, LineReaderImpl reader, Object completeType) throws Exception {
+		try {
+			doComplete.invoke(reader, completeType, false, false, false);
+		} catch (InvocationTargetException e) {
+			var cause = e.getCause();
+			if (!(cause instanceof EndOfFileException) && !(cause instanceof ClosedException)) {
+				throw e;
+			}
+		}
+	}
+
+	@Test
+	void shellCompletion_debugLogs_includePathCompletionRequestAndResponse_forMusicG() throws Exception {
+		try (var server = new MockApiServer()) {
+			server.registerPathCompletionByPath(Map.of(
+					"/music/G", "{\"completions\":[\"/Green_Day\"]}"
+			));
+
+			var sessionStore = new SessionStore();
+			sessionStore.save(server.baseUrl(), "jwt-debug-1");
+
+			var outBytes = new ByteArrayOutputStream();
+			var errBytes = new ByteArrayOutputStream();
+			var app      = new VempainFileCliApplication(sessionStore, new BackendClient(), new PrintStream(outBytes), new PrintStream(errBytes));
+
+			var debugField = VempainFileCliApplication.class.getDeclaredField("debugCompletion");
+			debugField.setAccessible(true);
+			debugField.setBoolean(app, true);
+
+			var completer  = app.createShellCompleterForTests();
+			var candidates = new ArrayList<Candidate>();
+			completer.complete(null, new StubParsedLine(List.of("scan", "--original-directory", "/music/G"), 2, "/music/G"), candidates);
+
+			var debugOutput = errBytes.toString(StandardCharsets.UTF_8);
+			assertTrue(debugOutput.contains("[completion-debug] path-completion request:"));
+			assertTrue(debugOutput.contains("\"path\":\"/music/G\""));
+			assertTrue(debugOutput.contains("[completion-debug] path-completion response:"));
+			assertTrue(debugOutput.contains("\"completions\":[\"/Green_Day\"]"));
+		}
+	}
+
+
+}


### PR DESCRIPTION
This pull request significantly improves the shell autocompletion logic for the CLI, especially for path completions and command options. The changes introduce more robust and context-aware suggestions, support for nested directory completions, and enhanced debugging capabilities. The test suite has also been expanded to verify these new behaviors.

**Shell autocompletion improvements:**

* Refactored the `CliCompleter` to provide context-aware command and option completions, including dynamic path suggestions for the `scan` command that handle nested directories, unique matches, and correct directory suffixes. Added debug logging for completion suggestions, controllable via a CLI flag or environment variable. [[1]](diffhunk://#diff-794edf47002060ef9cd7ccc8175fd7f91fb3a7070c732a09c99f706af3d38e53R39-R51) [[2]](diffhunk://#diff-794edf47002060ef9cd7ccc8175fd7f91fb3a7070c732a09c99f706af3d38e53L348-R439) [[3]](diffhunk://#diff-794edf47002060ef9cd7ccc8175fd7f91fb3a7070c732a09c99f706af3d38e53L389-R456)
* Added logic to prevent suggesting the `shell` command while already in shell mode and to track shell mode state to avoid recursion. [[1]](diffhunk://#diff-794edf47002060ef9cd7ccc8175fd7f91fb3a7070c732a09c99f706af3d38e53L115-R133) [[2]](diffhunk://#diff-794edf47002060ef9cd7ccc8175fd7f91fb3a7070c732a09c99f706af3d38e53L250-L257) [[3]](diffhunk://#diff-794edf47002060ef9cd7ccc8175fd7f91fb3a7070c732a09c99f706af3d38e53R297-R299)
* Introduced a static map of command options (`COMMAND_OPTIONS`) to enable option completion per command. [[1]](diffhunk://#diff-794edf47002060ef9cd7ccc8175fd7f91fb3a7070c732a09c99f706af3d38e53R39-R51) [[2]](diffhunk://#diff-794edf47002060ef9cd7ccc8175fd7f91fb3a7070c732a09c99f706af3d38e53L389-R456)

**Testing enhancements:**

* Expanded integration tests to cover various shell completion scenarios, including nested directory completions, unique match behaviors, and regression cases for multi-step path completions. [[1]](diffhunk://#diff-381a9c15c3df85b90c80eef47d295bd595a0d7bbfe794da5ed8c7cd319818b16L122-R138) [[2]](diffhunk://#diff-381a9c15c3df85b90c80eef47d295bd595a0d7bbfe794da5ed8c7cd319818b16L142-R247)

**Other improvements:**

* Improved argument splitting and parsing for quoted strings in commands.
* Minor code cleanups and visibility adjustments (e.g., making `main` non-public).

These changes make the CLI more user-friendly in interactive mode and ensure more reliable and intuitive completion suggestions.