### PR TITLE
Update dependencies to latest

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,44 +1,44 @@
 releaseVersion=0.0.1-SNAPSHOT
 javaVersion=25
 # https://mvnrepository.com/artifact/org.springframework.boot/spring-boot
-springBootVersion=4.0.6
+springBootVersion=4.1.0
 # https://mvnrepository.com/artifact/org.testcontainers/testcontainers
 testContainersVersion=2.0.5
 # https://mvnrepository.com/artifact/io.freefair.lombok/io.freefair.lombok.gradle.plugin
-ioFreeFairLombok=9.2.0
+ioFreeFairLombok=9.5.0
 # https://mvnrepository.com/artifact/org.json/json
-jsonVersion=20251224
+jsonVersion=20260522
 # https://mvnrepository.com/artifact/org.postgresql/postgresql
-postgresqlVersion=42.7.10
+postgresqlVersion=42.7.11
 # https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api
 jjwtVersion=0.13.0
 # https://mvnrepository.com/artifact/org.junit/junit-bom
-junitVersion=6.0.3
+junitVersion=6.1.1
 # https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-annotations
-swaggerVersion=2.2.48
+swaggerVersion=2.2.49
 # https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui
 springdocVersion=3.0.3
 # https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter
 mockitoVersion=5.23.0
-# https://mvnrepository.com/artifact/org.jline/jline
-jlineVersion=3.30.6
 # https://github.com/Vempain/vempain-auth/packages/2723219
 vempainAuthVersion=1.0.13
 # https://github.com/Vempain/vempain-admin-backend/packages/2624185
 vempainAdminVersion=1.0.27
 # https://mvnrepository.com/artifact/commons-codec/commons-codec
-commonsCodecVersion=1.21.0
+commonsCodecVersion=1.22.0
 # https://mvnrepository.com/artifact/jakarta.xml.bind/jakarta.xml.bind-api
 jakartaBindApiVersion=4.0.5
 # https://mvnrepository.com/artifact/jakarta.annotation/jakarta.annotation-api
 jakartaAnnotationApiVersion=3.0.0
-# https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-starter-openfeign
-springCloudStarterOpenfeignVersion=5.0.1
 # https://mvnrepository.com/artifact/net.coobird/thumbnailator
 thumbnailatorVersion=0.4.21
-# https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-dependencies
-springCloudVersion=2025.1.1
 # https://mvnrepository.com/artifact/io.spring.gradle/dependency-management-plugin
 gradleSpringPluginVersion=1.1.7
 # https://mvnrepository.com/artifact/org.jacoco/jacoco
-jacocoVersion=0.8.14
+jacocoVersion=0.8.15
+# https://mvnrepository.com/artifact/org.jline/jline
+jlineVersion=3.30.14
+# https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-starter-openfeign
+springCloudStarterOpenfeignVersion=5.0.2
+# https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-dependencies
+springCloudVersion=2025.1.2

--- a/service/src/main/java/fi/poltsi/vempain/file/tools/FileTool.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/tools/FileTool.java
@@ -14,6 +14,7 @@ public class FileTool {
 		try {
 			return DigestUtils.sha256Hex(Files.readAllBytes(file.toPath()));
 		} catch (IOException e) {
+			log.warn("Failed to generate sha256sum for file {}", file);
 			return null;
 		}
 	}


### PR DESCRIPTION
This pull request updates dependency versions in `gradle.properties` and improves error logging in the `FileTool` utility. The main focus is on keeping dependencies up-to-date and enhancing debugging for file hash computation failures.

Dependency updates:

* Bumped several dependencies to their latest versions, including `springBootVersion` (4.1.0), `ioFreeFairLombok` (9.5.0), `jsonVersion` (20260522), `postgresqlVersion` (42.7.11), `junitVersion` (6.1.1), `swaggerVersion` (2.2.49), `commonsCodecVersion` (1.22.0), `jacocoVersion` (0.8.15), `jlineVersion` (3.30.14), `springCloudStarterOpenfeignVersion` (5.0.2), and `springCloudVersion` (2025.1.2).

Error handling improvement:

* Added a warning log statement in `FileTool.computeSha256` to log failures when generating a SHA-256 hash for a file, aiding in debugging.