### PR TITLE
Improve the parsing of datetime strings in MetadataTool

### DIFF
--- a/service/src/main/java/fi/poltsi/vempain/file/tools/MetadataTool.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/tools/MetadataTool.java
@@ -1500,6 +1500,15 @@ public class MetadataTool {
 			}
 		}
 
+		var normalized  = trimmed;
+		var offsetStart = Math.max(trimmed.lastIndexOf('+'), trimmed.lastIndexOf('-'));
+		if (offsetStart > 0) {
+			var offset = trimmed.substring(offsetStart);
+			if (offset.matches("[+-]\\d:\\d{2}")) {
+				normalized = trimmed.substring(0, offsetStart) + offset.charAt(0) + "0" + offset.substring(1);
+			}
+		}
+
 		var formatter = new DateTimeFormatterBuilder()
 				// Date
 				.appendPattern("yyyy:MM:dd HH:mm")
@@ -1519,7 +1528,7 @@ public class MetadataTool {
 				.withZone(ZoneId.systemDefault());
 
 		try {
-			var timeStamp = formatter.parse(trimmed, Instant::from);
+			var timeStamp = formatter.parse(normalized, Instant::from);
 			log.debug("Parsed date time string '{}' to Instant: {}", dateTimeString, timeStamp);
 			return timeStamp;
 		} catch (DateTimeParseException e) {

--- a/service/src/test/java/fi/poltsi/vempain/file/tools/MetadataToolExtendedUTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/tools/MetadataToolExtendedUTC.java
@@ -6,20 +6,14 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Extended unit tests (UTC) for {@link MetadataTool} JSON-based extraction methods.

--- a/service/src/test/java/fi/poltsi/vempain/file/tools/MetadataToolUTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/tools/MetadataToolUTC.java
@@ -22,6 +22,7 @@ class MetadataToolUTC {
 			"2006:11:19 00:04:34+02:00",
 			"2008:03:20 21:14:46.00+02:00",
 			"2014:06:24 09:34:01.761+03:00",
+			"2012:02:27 23:08:27+3:00",
 			"2022:07:07 17:35:12.1Z",
 			"2016:10:27 04:50+02:00"
 	})
@@ -32,7 +33,8 @@ class MetadataToolUTC {
 
 	@ParameterizedTest
 	@CsvSource({
-			"2016:10:27 04:50+02:00,2016-10-27T02:50:00Z"
+			"2016:10:27 04:50+02:00,2016-10-27T02:50:00Z",
+			"2012:02:27 23:08:27+3:00,2012-02-27T20:08:27Z"
 	})
 	void dateTimeParser_parsesWithoutSeconds(String input, String expectedUtc) {
 		assertEquals(Instant.parse(expectedUtc), MetadataTool.dateTimeParser(input));


### PR DESCRIPTION
This pull request improves the robustness of the `dateTimeParser` method in `MetadataTool` by normalizing timezone offsets in date-time strings before parsing. It also adds new test cases to ensure correct handling of these formats and cleans up unused imports in test files.

**Date-time parsing improvements:**

* Enhanced the `dateTimeParser` method in `MetadataTool` to normalize timezone offsets of the form `+h:mm` or `-h:mm` to `+0h:mm` or `-0h:mm`, ensuring correct parsing of single-digit hour offsets. [[1]](diffhunk://#diff-5d0a525acce043c1391da9c9cfd0fb6fcc557c434be66f8218f369ecd2482649R1503-R1511) [[2]](diffhunk://#diff-5d0a525acce043c1391da9c9cfd0fb6fcc557c434be66f8218f369ecd2482649L1522-R1531)

**Testing improvements:**

* Added new test cases in `MetadataToolUTC` to cover date-time strings with single-digit hour offsets, such as `2012:02:27 23:08:27+3:00`, verifying correct parsing to UTC. [[1]](diffhunk://#diff-1472b53581a5fb9bb76868c93011ebb648c4348f71421c08a5f54b6d48a5def3R25) [[2]](diffhunk://#diff-1472b53581a5fb9bb76868c93011ebb648c4348f71421c08a5f54b6d48a5def3L35-R37)
* Removed unused imports from `MetadataToolExtendedUTC` test file for code cleanliness.