### PR TITLE
Add statistics API and response model for file database metrics

### DIFF
--- a/api/src/main/java/fi/poltsi/vempain/file/api/response/FileStatisticsResponse.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/api/response/FileStatisticsResponse.java
@@ -1,0 +1,34 @@
+package fi.poltsi.vempain.file.api.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.annotation.JsonNaming;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class FileStatisticsResponse {
+	private long                            totalFiles;
+	private Map<String, Long>               filesByType;
+	private Map<String, Map<Integer, Long>> filesByTypeAndYear;
+	private long                            totalTags;
+	private long                            totalGpsLocations;
+	private long                            filesWithGpsLocations;
+	private long                            filesWithTags;
+	private long                            largestFileGroupSize;
+	private long                            smallestFileGroupSize;
+	private BigDecimal                      averageFileGroupSize;
+	private long                            totalFileSize;
+	private long                            largestFileSize;
+	private BigDecimal                      averageFileSize;
+	private Map<String, Long>               largestFileSizeByType;
+	private Map<String, BigDecimal>         averageFileSizeByType;
+}

--- a/api/src/main/java/fi/poltsi/vempain/file/rest/FileContentAPI.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/rest/FileContentAPI.java
@@ -30,4 +30,3 @@ public interface FileContentAPI {
 	@GetMapping(path = BASE_PATH + "/{id}/content", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
 	ResponseEntity<Resource> getFileContent(@PathVariable("id") long id);
 }
-

--- a/api/src/main/java/fi/poltsi/vempain/file/rest/StatisticsAPI.java
+++ b/api/src/main/java/fi/poltsi/vempain/file/rest/StatisticsAPI.java
@@ -1,0 +1,19 @@
+package fi.poltsi.vempain.file.rest;
+
+import fi.poltsi.vempain.file.api.response.FileStatisticsResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Tag(name = "StatisticsAPI", description = "Operations for retrieving file database statistics")
+public interface StatisticsAPI {
+	String BASE_PATH = "/statistics";
+
+	@Operation(summary = "Get file database statistics", tags = "StatisticsAPI")
+	@SecurityRequirement(name = "******")
+	@GetMapping(path = BASE_PATH, produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<FileStatisticsResponse> getStatistics();
+}

--- a/service/src/main/java/fi/poltsi/vempain/file/controller/StatisticsController.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/controller/StatisticsController.java
@@ -1,0 +1,19 @@
+package fi.poltsi.vempain.file.controller;
+
+import fi.poltsi.vempain.file.api.response.FileStatisticsResponse;
+import fi.poltsi.vempain.file.rest.StatisticsAPI;
+import fi.poltsi.vempain.file.service.StatisticsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class StatisticsController implements StatisticsAPI {
+	private final StatisticsService statisticsService;
+
+	@Override
+	public ResponseEntity<FileStatisticsResponse> getStatistics() {
+		return ResponseEntity.ok(statisticsService.getStatistics());
+	}
+}

--- a/service/src/main/java/fi/poltsi/vempain/file/repository/files/FileRepository.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/repository/files/FileRepository.java
@@ -3,8 +3,11 @@ package fi.poltsi.vempain.file.repository.files;
 import fi.poltsi.vempain.file.entity.FileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.math.BigDecimal;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -12,4 +15,44 @@ public interface FileRepository extends JpaRepository<FileEntity, Long>, JpaSpec
 	Optional<FileEntity> findByFilePathAndFilename(String filePath, String filename);
 
 	FileEntity findByOriginalDocumentId(String originalDocumentId);
+
+	@Query(value = "SELECT file_type AS fileType, COUNT(*) AS fileCount FROM files GROUP BY file_type", nativeQuery = true)
+	List<FileTypeCountProjection> countFilesByType();
+
+	@Query(value = """
+			SELECT file_type AS fileType, EXTRACT(YEAR FROM original_datetime)::int AS creationYear, COUNT(*) AS fileCount
+			FROM files
+			WHERE original_datetime IS NOT NULL
+			GROUP BY file_type, EXTRACT(YEAR FROM original_datetime)
+			""", nativeQuery = true)
+	List<FileTypeYearCountProjection> countFilesByTypeAndCreationYear();
+
+	@Query(value = "SELECT COUNT(DISTINCT gps_location_id) FROM files WHERE gps_location_id IS NOT NULL", nativeQuery = true)
+	long countFilesWithGpsLocations();
+
+	@Query(value = "SELECT COUNT(DISTINCT file_id) FROM file_tags", nativeQuery = true)
+	long countFilesWithTags();
+
+	@Query(value = "SELECT COUNT(*) FROM files", nativeQuery = true)
+	long countTotalFiles();
+
+	@Query(value = "SELECT COALESCE(SUM(filesize), 0) FROM files", nativeQuery = true)
+	long sumFileSizes();
+
+	@Query(value = "SELECT COALESCE(MAX(filesize), 0) FROM files", nativeQuery = true)
+	long maxFileSize();
+
+	@Query(value = "SELECT COALESCE(AVG(filesize), 0) FROM files", nativeQuery = true)
+	BigDecimal averageFileSize();
+
+	@Query(value = """
+			SELECT file_type AS fileType, MAX(filesize) AS largestFileSize, AVG(filesize) AS averageFileSize
+			FROM files
+			GROUP BY file_type
+			""", nativeQuery = true)
+	List<FileTypeSizeProjection> summarizeFileSizesByType();
+
+	@Query(value = "SELECT COUNT(fgf.file_id) FROM file_group fg LEFT JOIN file_group_files fgf ON fgf.file_group_id = fg.id GROUP BY fg.id",
+	       nativeQuery = true)
+	List<Long> findFileGroupSizes();
 }

--- a/service/src/main/java/fi/poltsi/vempain/file/repository/files/FileTypeCountProjection.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/repository/files/FileTypeCountProjection.java
@@ -1,0 +1,7 @@
+package fi.poltsi.vempain.file.repository.files;
+
+public interface FileTypeCountProjection {
+	String getFileType();
+
+	Long getFileCount();
+}

--- a/service/src/main/java/fi/poltsi/vempain/file/repository/files/FileTypeSizeProjection.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/repository/files/FileTypeSizeProjection.java
@@ -1,0 +1,11 @@
+package fi.poltsi.vempain.file.repository.files;
+
+import java.math.BigDecimal;
+
+public interface FileTypeSizeProjection {
+	String getFileType();
+
+	Long getLargestFileSize();
+
+	BigDecimal getAverageFileSize();
+}

--- a/service/src/main/java/fi/poltsi/vempain/file/repository/files/FileTypeYearCountProjection.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/repository/files/FileTypeYearCountProjection.java
@@ -1,0 +1,9 @@
+package fi.poltsi.vempain.file.repository.files;
+
+public interface FileTypeYearCountProjection {
+	String getFileType();
+
+	Integer getCreationYear();
+
+	Long getFileCount();
+}

--- a/service/src/main/java/fi/poltsi/vempain/file/service/StatisticsService.java
+++ b/service/src/main/java/fi/poltsi/vempain/file/service/StatisticsService.java
@@ -1,0 +1,91 @@
+package fi.poltsi.vempain.file.service;
+
+import fi.poltsi.vempain.file.api.FileTypeEnum;
+import fi.poltsi.vempain.file.api.response.FileStatisticsResponse;
+import fi.poltsi.vempain.file.repository.GpsLocationRepository;
+import fi.poltsi.vempain.file.repository.TagRepository;
+import fi.poltsi.vempain.file.repository.files.FileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class StatisticsService {
+	private final FileRepository        fileRepository;
+	private final TagRepository         tagRepository;
+	private final GpsLocationRepository gpsLocationRepository;
+
+	public FileStatisticsResponse getStatistics() {
+		final List<Long> groupSizes = fileRepository.findFileGroupSizes();
+		final Map<String, Long> filesByType = fileRepository.countFilesByType()
+		                                                    .stream()
+															.collect(Collectors.toMap(
+																	projection -> fileTypeName(projection.getFileType()),
+																	projection -> projection.getFileCount(),
+																	Long::sum,
+																	LinkedHashMap::new));
+		final Map<String, Map<Integer, Long>> filesByTypeAndYear = fileRepository.countFilesByTypeAndCreationYear()
+		                                                                         .stream()
+																				 .collect(Collectors.groupingBy(
+																						 projection -> fileTypeName(projection.getFileType()),
+																						 LinkedHashMap::new,
+																						 Collectors.toMap(
+																								 projection -> projection.getCreationYear(),
+																								 projection -> projection.getFileCount(),
+																								 Long::sum,
+																								 LinkedHashMap::new)));
+		final Map<String, Long>       largestByType = new LinkedHashMap<>();
+		final Map<String, BigDecimal> averageByType = new LinkedHashMap<>();
+		fileRepository.summarizeFileSizesByType()
+		              .forEach(projection -> {
+						  final String type = fileTypeName(projection.getFileType());
+						  largestByType.put(type, projection.getLargestFileSize());
+						  averageByType.put(type, scale(projection.getAverageFileSize()));
+					  });
+
+		return FileStatisticsResponse.builder()
+									 .totalFiles(fileRepository.countTotalFiles())
+									 .filesByType(filesByType)
+									 .filesByTypeAndYear(filesByTypeAndYear)
+									 .totalTags(tagRepository.count())
+									 .totalGpsLocations(gpsLocationRepository.count())
+									 .filesWithGpsLocations(fileRepository.countFilesWithGpsLocations())
+									 .filesWithTags(fileRepository.countFilesWithTags())
+									 .largestFileGroupSize(groupSizes.stream()
+		                                                             .max(Comparator.naturalOrder())
+		                                                             .orElse(0L))
+									 .smallestFileGroupSize(groupSizes.stream()
+		                                                              .min(Comparator.naturalOrder())
+		                                                              .orElse(0L))
+									 .averageFileGroupSize(average(groupSizes))
+									 .totalFileSize(fileRepository.sumFileSizes())
+									 .largestFileSize(fileRepository.maxFileSize())
+									 .averageFileSize(scale(fileRepository.averageFileSize()))
+									 .largestFileSizeByType(largestByType)
+									 .averageFileSizeByType(averageByType)
+									 .build();
+	}
+
+	private String fileTypeName(String fileType) {
+		return FileTypeEnum.valueOf(fileType).shortName;
+	}
+
+	private BigDecimal average(List<Long> values) {
+		return values.isEmpty() ? BigDecimal.ZERO : BigDecimal.valueOf(values.stream()
+		                                                                     .mapToLong(Long::longValue)
+		                                                                     .average()
+		                                                                     .orElse(0));
+	}
+
+	private BigDecimal scale(BigDecimal value) {
+		return value == null ? BigDecimal.ZERO : value.setScale(2, RoundingMode.HALF_UP);
+	}
+}

--- a/service/src/test/java/fi/poltsi/vempain/file/service/StatisticsServiceUTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/file/service/StatisticsServiceUTC.java
@@ -1,0 +1,92 @@
+package fi.poltsi.vempain.file.service;
+
+import fi.poltsi.vempain.file.repository.GpsLocationRepository;
+import fi.poltsi.vempain.file.repository.TagRepository;
+import fi.poltsi.vempain.file.repository.files.FileRepository;
+import fi.poltsi.vempain.file.repository.files.FileTypeCountProjection;
+import fi.poltsi.vempain.file.repository.files.FileTypeSizeProjection;
+import fi.poltsi.vempain.file.repository.files.FileTypeYearCountProjection;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StatisticsServiceUTC {
+	@Mock
+	private FileRepository        fileRepository;
+	@Mock
+	private TagRepository         tagRepository;
+	@Mock
+	private GpsLocationRepository gpsLocationRepository;
+	@InjectMocks
+	private StatisticsService     statisticsService;
+
+	@Test
+	void getStatistics_assemblesAllMetrics() {
+		var type = mock(FileTypeCountProjection.class);
+		when(type.getFileType()).thenReturn("IMAGE");
+		when(type.getFileCount()).thenReturn(3L);
+		var year = mock(FileTypeYearCountProjection.class);
+		when(year.getFileType()).thenReturn("IMAGE");
+		when(year.getCreationYear()).thenReturn(2024);
+		when(year.getFileCount()).thenReturn(2L);
+		var size = mock(FileTypeSizeProjection.class);
+		when(size.getFileType()).thenReturn("IMAGE");
+		when(size.getLargestFileSize()).thenReturn(900L);
+		when(size.getAverageFileSize()).thenReturn(new BigDecimal("450.125"));
+		when(fileRepository.countFilesByType()).thenReturn(List.of(type));
+		when(fileRepository.countFilesByTypeAndCreationYear()).thenReturn(List.of(year));
+		when(fileRepository.summarizeFileSizesByType()).thenReturn(List.of(size));
+		when(fileRepository.findFileGroupSizes()).thenReturn(List.of(2L, 4L));
+		when(fileRepository.countTotalFiles()).thenReturn(3L);
+		when(fileRepository.countFilesWithGpsLocations()).thenReturn(1L);
+		when(fileRepository.countFilesWithTags()).thenReturn(2L);
+		when(fileRepository.sumFileSizes()).thenReturn(1350L);
+		when(fileRepository.maxFileSize()).thenReturn(900L);
+		when(fileRepository.averageFileSize()).thenReturn(new BigDecimal("450.125"));
+		when(tagRepository.count()).thenReturn(5L);
+		when(gpsLocationRepository.count()).thenReturn(2L);
+
+		var response = statisticsService.getStatistics();
+
+		assertThat(response.getTotalFiles()).isEqualTo(3);
+		assertThat(response.getFilesByType()).containsEntry("image", 3L);
+		assertThat(response.getFilesByTypeAndYear()).containsEntry("image", java.util.Map.of(2024, 2L));
+		assertThat(response.getTotalTags()).isEqualTo(5);
+		assertThat(response.getTotalGpsLocations()).isEqualTo(2);
+		assertThat(response.getFilesWithGpsLocations()).isEqualTo(1);
+		assertThat(response.getFilesWithTags()).isEqualTo(2);
+		assertThat(response.getLargestFileGroupSize()).isEqualTo(4);
+		assertThat(response.getSmallestFileGroupSize()).isEqualTo(2);
+		assertThat(response.getAverageFileGroupSize()).isEqualByComparingTo("3");
+		assertThat(response.getAverageFileSize()).isEqualByComparingTo("450.13");
+		assertThat(response.getAverageFileSizeByType()).containsEntry("image", new BigDecimal("450.13"));
+	}
+
+	@Test
+	void getStatistics_emptyDatabaseReturnsZeroesAndEmptyMaps() {
+		when(fileRepository.countFilesByType()).thenReturn(List.of());
+		when(fileRepository.countFilesByTypeAndCreationYear()).thenReturn(List.of());
+		when(fileRepository.summarizeFileSizesByType()).thenReturn(List.of());
+		when(fileRepository.findFileGroupSizes()).thenReturn(List.of());
+		when(fileRepository.averageFileSize()).thenReturn(BigDecimal.ZERO);
+
+		var response = statisticsService.getStatistics();
+
+		assertThat(response.getTotalFiles()).isZero();
+		assertThat(response.getLargestFileGroupSize()).isZero();
+		assertThat(response.getSmallestFileGroupSize()).isZero();
+		assertThat(response.getAverageFileGroupSize()).isZero();
+		assertThat(response.getFilesByType()).isEmpty();
+		assertThat(response.getAverageFileSize()).isZero();
+	}
+}


### PR DESCRIPTION
This pull request introduces a comprehensive statistics API for the file service, enabling retrieval of various aggregated metrics about files, tags, and GPS locations. It adds a new REST endpoint, implements the service and controller logic, extends the repository with efficient native queries, and provides projections and tests for robust metric calculation.

**API and Endpoint Additions:**

* Added the `StatisticsAPI` interface, defining a `/statistics` endpoint that returns a `FileStatisticsResponse` with detailed database metrics.
* Implemented `StatisticsController` to expose the statistics endpoint and delegate to the service layer.

**Service Layer Implementation:**

* Introduced `StatisticsService` to aggregate metrics such as file counts by type and year, tag and GPS counts, file group sizes, and file size statistics, using new repository queries and projections.

**Repository and Data Access Enhancements:**

* Extended `FileRepository` with native SQL queries for efficient aggregation, including counts and summaries by file type, year, and group, and added projections (`FileTypeCountProjection`, `FileTypeYearCountProjection`, `FileTypeSizeProjection`) to map query results. [[1]](diffhunk://#diff-7b068ec8e4845a03845176db134ad79bb945fa8c6a6ae46e57a91821ba9614fcR6-R57) [[2]](diffhunk://#diff-626157f2f1947d50509ed12ea6fab042520dd4d88e4f8bffc6bbc08be89ddf9fR1-R7) [[3]](diffhunk://#diff-555bea43aa388ab2b509022e3f47b840ba364f6c70ae534904dfd11dbaef7f01R1-R9) [[4]](diffhunk://#diff-6fa7b6794612500b1ea5e962e83585575462d0cbb1491d12f922378aa65f1d2bR1-R11)

**Data Model and Serialization:**

* Added `FileStatisticsResponse` DTO to encapsulate and serialize all statistics in a structured JSON response.

**Testing:**

* Added `StatisticsServiceUTC` unit tests to verify correct aggregation and edge cases for the statistics logic.